### PR TITLE
Refactor groups hero into dedicated component

### DIFF
--- a/front/src/pages/Groups.css
+++ b/front/src/pages/Groups.css
@@ -4,141 +4,6 @@
   gap: 32px;
 }
 
-.groups-page .groups-hero {
-  display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 24px;
-  padding: 32px;
-  border-radius: 24px;
-  background: linear-gradient(135deg, rgba(52, 152, 219, 0.08), rgba(52, 152, 219, 0.02));
-  border: 1px solid rgba(52, 152, 219, 0.15);
-  box-shadow: 0 24px 48px -32px rgba(52, 152, 219, 0.4);
-}
-
-.app.dark-mode .groups-page .groups-hero {
-  background: linear-gradient(135deg, rgba(93, 173, 226, 0.15), rgba(46, 134, 193, 0.05));
-  border-color: rgba(93, 173, 226, 0.2);
-  box-shadow: 0 30px 60px -40px rgba(93, 173, 226, 0.65);
-}
-
-.groups-page .groups-hero__content {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.groups-page .groups-hero__subtitle {
-  font-size: 16px;
-  line-height: 1.6;
-  color: var(--text-secondary);
-  max-width: 640px;
-}
-
-.groups-page .groups-stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 20px;
-}
-
-.groups-page .groups-stat-card {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 20px 22px;
-  border-radius: 18px;
-  border: 1px solid rgba(52, 152, 219, 0.12);
-  background-color: var(--bg-secondary);
-  box-shadow: 0 18px 32px -28px rgba(0, 0, 0, 0.25);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.groups-page .groups-stat-card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 22px 48px -28px rgba(52, 152, 219, 0.35);
-}
-
-.groups-page .groups-stat-card__label {
-  font-size: 14px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(52, 73, 94, 0.7);
-}
-
-.app.dark-mode .groups-page .groups-stat-card__label {
-  color: rgba(236, 240, 241, 0.65);
-}
-
-.groups-page .groups-stat-card__value {
-  font-size: 36px;
-  font-weight: 700;
-  color: #3498db;
-}
-
-.app.dark-mode .groups-page .groups-stat-card__value {
-  color: #5dade2;
-}
-
-.groups-page .groups-stat-card__hint {
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--text-secondary);
-}
-
-.groups-page .groups-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 8px 16px;
-  border-radius: 999px;
-  font-weight: 600;
-  font-size: 14px;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-
-.groups-page .groups-badge--loading {
-  background: rgba(241, 196, 15, 0.18);
-  color: #f1c40f;
-}
-
-.groups-page .groups-badge--ready {
-  background: rgba(46, 204, 113, 0.18);
-  color: #27ae60;
-}
-
-.groups-page .groups-hero__side {
-  display: flex;
-  align-items: stretch;
-}
-
-.groups-page .groups-hero__card {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 24px 26px;
-  border-radius: 18px;
-  background-color: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  box-shadow: 0 18px 32px -28px rgba(0, 0, 0, 0.25);
-}
-
-.groups-page .groups-hero__title {
-  font-size: 20px;
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.groups-page .groups-hero__list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  color: var(--text-secondary);
-  font-size: 15px;
-  line-height: 1.6;
-  padding-left: 18px;
-}
-
 .groups-page .groups-actions {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 1px minmax(0, 1fr);
@@ -182,14 +47,6 @@
 }
 
 @media (max-width: 900px) {
-  .groups-page .groups-hero {
-    grid-template-columns: 1fr;
-  }
-
-  .groups-page .groups-hero__side {
-    order: -1;
-  }
-
   .groups-page .groups-divider {
     display: none;
   }
@@ -263,7 +120,6 @@
 }
 
 @media (max-width: 600px) {
-  .groups-page .groups-hero,
   .groups-page .groups-actions,
   .groups-page .groups-table-card {
     padding: 20px;
@@ -273,10 +129,6 @@
   .groups-page .groups-table-card__actions {
     width: 100%;
     align-items: stretch;
-  }
-
-  .groups-page .groups-stat-card__value {
-    font-size: 28px;
   }
 
   .groups-page .groups-table-card__title {

--- a/front/src/pages/Groups.tsx
+++ b/front/src/pages/Groups.tsx
@@ -1,5 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
-import PageTitle from '../components/PageTitle'
+import { useState, useEffect } from 'react'
 import Table from '../components/Table'
 import GroupInput from '../components/GroupInput'
 import Button from '../components/Button'
@@ -7,19 +6,19 @@ import FileUpload from '../components/FileUpload'
 import { useGroupsStore } from '../stores'
 import { getGroupTableColumns } from '../config/groupTableColumns'
 import './Groups.css'
+import GroupsHero from './Groups/components/GroupsHero'
 
 function Groups() {
   const groups = useGroupsStore((state) => state.groups)
   const isLoading = useGroupsStore((state) => state.isLoading)
+  const totalGroups = useGroupsStore((state) => state.groups.length)
+  const hasGroups = useGroupsStore((state) => state.groups.length > 0)
   const fetchGroups = useGroupsStore((state) => state.fetchGroups)
   const addGroup = useGroupsStore((state) => state.addGroup)
   const deleteGroup = useGroupsStore((state) => state.deleteGroup)
   const loadFromFile = useGroupsStore((state) => state.loadFromFile)
   const deleteAllGroups = useGroupsStore((state) => state.deleteAllGroups)
   const [url, setUrl] = useState('')
-
-  const totalGroups = useMemo(() => groups.length, [groups])
-  const hasGroups = totalGroups > 0
 
   useEffect(() => {
     fetchGroups()
@@ -59,52 +58,11 @@ function Groups() {
 
   return (
     <div className="groups-page">
-      <section className="groups-hero">
-        <div className="groups-hero__content">
-          <PageTitle>Группы</PageTitle>
-          <p className="groups-hero__subtitle">
-            Управляйте списком сообществ, добавляйте новые источники вручную или импортируйте их из файла.
-            Сводка ниже помогает оценить состояние каталога и статус обновления данных.
-          </p>
-
-          <div className="groups-stats">
-            <div className="groups-stat-card">
-              <span className="groups-stat-card__label">Всего групп</span>
-              <span className="groups-stat-card__value">{isLoading ? '—' : totalGroups}</span>
-              <span className="groups-stat-card__hint">
-                {isLoading
-                  ? 'Получаем актуальный список сообществ'
-                  : hasGroups
-                    ? 'Список готов к работе — таблица ниже покажет подробности'
-                    : 'Пока что список пуст — добавьте первую группу, чтобы начать'}
-              </span>
-            </div>
-
-            <div className="groups-stat-card">
-              <span className="groups-stat-card__label">Статус обновления</span>
-              <span className={`groups-badge ${isLoading ? 'groups-badge--loading' : 'groups-badge--ready'}`}>
-                {isLoading ? 'Обновляем данные' : 'Актуальные данные'}
-              </span>
-              <span className="groups-stat-card__hint">
-                {isLoading
-                  ? 'Это может занять несколько секунд'
-                  : 'Последняя загрузка данных завершена успешно'}
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <aside className="groups-hero__side">
-          <div className="groups-hero__card">
-            <h2 className="groups-hero__title">Как начать работу</h2>
-            <ul className="groups-hero__list">
-              <li>Вставьте ссылку на сообщество ВК и нажмите «Добавить».</li>
-              <li>Загрузите заранее подготовленный файл со списком ссылок.</li>
-              <li>Следите за статусом импорта — новые записи появятся в таблице автоматически.</li>
-            </ul>
-          </div>
-        </aside>
-      </section>
+      <GroupsHero
+        isLoading={isLoading}
+        totalGroups={totalGroups}
+        hasGroups={hasGroups}
+      />
 
       <section className="groups-actions">
         <div className="groups-actions__block">

--- a/front/src/pages/Groups/components/GroupsHero.module.css
+++ b/front/src/pages/Groups/components/GroupsHero.module.css
@@ -1,0 +1,269 @@
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  gap: 28px;
+  padding: 32px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(52, 152, 219, 0.1), rgba(52, 152, 219, 0.03));
+  border: 1px solid rgba(52, 152, 219, 0.18);
+  box-shadow: 0 28px 54px -36px rgba(52, 152, 219, 0.45);
+}
+
+:global(.app.dark-mode) .hero {
+  background: linear-gradient(135deg, rgba(93, 173, 226, 0.16), rgba(40, 116, 166, 0.08));
+  border-color: rgba(93, 173, 226, 0.25);
+  box-shadow: 0 34px 64px -44px rgba(93, 173, 226, 0.7);
+}
+
+.overview {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.subtitle {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-width: 640px;
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.statCard {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 22px 24px;
+  border-radius: 20px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 22px 44px -36px rgba(0, 0, 0, 0.28);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.statCard:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 26px 48px -32px rgba(52, 152, 219, 0.38);
+}
+
+.statCardPrimary {
+  background: linear-gradient(135deg, rgba(52, 152, 219, 0.12), rgba(52, 152, 219, 0));
+  border-color: rgba(52, 152, 219, 0.28);
+}
+
+:global(.app.dark-mode) .statCardPrimary {
+  background: linear-gradient(135deg, rgba(93, 173, 226, 0.25), rgba(52, 152, 219, 0.05));
+  border-color: rgba(93, 173, 226, 0.35);
+}
+
+.statHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.statLabel {
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(52, 73, 94, 0.7);
+}
+
+:global(.app.dark-mode) .statLabel {
+  color: rgba(236, 240, 241, 0.7);
+}
+
+.statValueRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.statValue {
+  font-size: 40px;
+  font-weight: 700;
+  color: #3498db;
+}
+
+:global(.app.dark-mode) .statValue {
+  color: #5dade2;
+}
+
+.statBadgeSoft {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(52, 152, 219, 0.16);
+  color: #1b4f72;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+:global(.app.dark-mode) .statBadgeSoft {
+  background: rgba(93, 173, 226, 0.28);
+  color: rgba(236, 240, 241, 0.9);
+}
+
+.statDescription {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.statusBadgeLoading {
+  background: rgba(241, 196, 15, 0.2);
+  color: #d4ac0d;
+}
+
+.statusBadgeReady {
+  background: rgba(46, 204, 113, 0.2);
+  color: #1e8449;
+}
+
+:global(.app.dark-mode) .statusBadgeLoading {
+  background: rgba(241, 196, 15, 0.28);
+  color: #f9e79f;
+}
+
+:global(.app.dark-mode) .statusBadgeReady {
+  background: rgba(46, 204, 113, 0.28);
+  color: #7dcea0;
+}
+
+.guide {
+  display: flex;
+  align-items: stretch;
+}
+
+.guideCard {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 26px;
+  border-radius: 20px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 22px 44px -36px rgba(0, 0, 0, 0.3);
+}
+
+.guideTitle {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.guideIntro {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.guideList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.guideItem {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.stepBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(52, 152, 219, 0.18);
+  color: #1b4f72;
+  font-weight: 700;
+  font-size: 16px;
+}
+
+:global(.app.dark-mode) .stepBadge {
+  background: rgba(93, 173, 226, 0.32);
+  color: rgba(236, 240, 241, 0.9);
+}
+
+.stepTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.stepText {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 1100px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .guide {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 24px;
+    border-radius: 20px;
+  }
+
+  .statsGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero {
+    padding: 20px;
+    border-radius: 18px;
+  }
+
+  .statValue {
+    font-size: 32px;
+  }
+
+  .guideCard {
+    padding: 22px;
+  }
+}

--- a/front/src/pages/Groups/components/GroupsHero.tsx
+++ b/front/src/pages/Groups/components/GroupsHero.tsx
@@ -1,0 +1,99 @@
+import PageTitle from '../../../components/PageTitle'
+import styles from './GroupsHero.module.css'
+
+type GroupsHeroProps = {
+  isLoading: boolean
+  totalGroups: number
+  hasGroups: boolean
+}
+
+function GroupsHero({ isLoading, totalGroups, hasGroups }: GroupsHeroProps) {
+  const badgeClassName = `${styles.statusBadge} ${isLoading ? styles.statusBadgeLoading : styles.statusBadgeReady}`
+
+  return (
+    <section className={styles.hero}>
+      <div className={styles.overview}>
+        <div className={styles.header}>
+          <PageTitle>Группы</PageTitle>
+          <p className={styles.subtitle}>
+            Управляйте списком сообществ: добавляйте новые источники вручную, импортируйте их из файлов и
+            отслеживайте состояние каталога. Ниже — быстрый срез по количеству и статусу обновления данных.
+          </p>
+        </div>
+
+        <div className={styles.statsGrid}>
+          <article className={`${styles.statCard} ${styles.statCardPrimary}`}>
+            <header className={styles.statHeader}>
+              <span className={styles.statLabel}>Всего групп</span>
+            </header>
+            <div className={styles.statValueRow}>
+              <span className={styles.statValue}>{isLoading ? '—' : totalGroups}</span>
+              {!isLoading && (
+                <span className={styles.statBadgeSoft}>
+                  {hasGroups ? 'Каталог активен' : 'Пока пусто'}
+                </span>
+              )}
+            </div>
+            <p className={styles.statDescription}>
+              {isLoading
+                ? 'Получаем актуальные данные — таблица ниже обновится автоматически.'
+                : hasGroups
+                  ? 'Список готов к работе: управляйте сообществами и следите за их состоянием ниже.'
+                  : 'Список пуст. Добавьте первую группу или воспользуйтесь импортом, чтобы начать анализ.'}
+            </p>
+          </article>
+
+          <article className={styles.statCard}>
+            <header className={styles.statHeader}>
+              <span className={styles.statLabel}>Статус синхронизации</span>
+            </header>
+            <span className={badgeClassName}>
+              {isLoading ? 'Обновляем данные' : 'Актуальные данные'}
+            </span>
+            <p className={styles.statDescription}>
+              {isLoading
+                ? 'Это займёт немного времени. Мы загрузим и проверим новые записи.'
+                : hasGroups
+                  ? 'Последняя синхронизация прошла успешно. Новые данные отображаются в таблице.'
+                  : 'Как только вы добавите группы, здесь появится статус их последней загрузки.'}
+            </p>
+          </article>
+        </div>
+      </div>
+
+      <aside className={styles.guide}>
+        <div className={styles.guideCard}>
+          <h2 className={styles.guideTitle}>Как начать работу</h2>
+          <p className={styles.guideIntro}>
+            Следуйте шагам, чтобы быстро собрать каталог сообществ и подготовить данные к анализу.
+          </p>
+          <ol className={styles.guideList}>
+            <li className={styles.guideItem}>
+              <span className={styles.stepBadge}>1</span>
+              <div>
+                <h3 className={styles.stepTitle}>Добавьте ссылку</h3>
+                <p className={styles.stepText}>Вставьте URL сообщества ВК и нажмите «Добавить».</p>
+              </div>
+            </li>
+            <li className={styles.guideItem}>
+              <span className={styles.stepBadge}>2</span>
+              <div>
+                <h3 className={styles.stepTitle}>Импортируйте файл</h3>
+                <p className={styles.stepText}>Загрузите текстовый список ссылок, чтобы ускорить наполнение.</p>
+              </div>
+            </li>
+            <li className={styles.guideItem}>
+              <span className={styles.stepBadge}>3</span>
+              <div>
+                <h3 className={styles.stepTitle}>Проверьте статус</h3>
+                <p className={styles.stepText}>Отслеживайте прогресс — новые записи сразу появятся в таблице.</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </aside>
+    </section>
+  )
+}
+
+export default GroupsHero


### PR DESCRIPTION
## Summary
- move the groups hero markup into a new GroupsHero component under pages/Groups/components
- implement the redesigned hero layout with refreshed statistics cards, onboarding steps, and a CSS module that supports dark mode
- update Groups.tsx to wire the hero to store-derived state and prune the legacy global hero styles

## Testing
- npm run build *(emits existing css-syntax warning from Comments.css)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ffb63cc48332b79f5cbcfe072180