### PR TITLE
feat(front): add groups actions panel component

### DIFF
--- a/front/src/pages/Groups.css
+++ b/front/src/pages/Groups.css
@@ -139,47 +139,6 @@
   padding-left: 18px;
 }
 
-.groups-page .groups-actions {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 1px minmax(0, 1fr);
-  gap: 24px;
-  align-items: start;
-  padding: 28px 32px;
-  border-radius: 22px;
-  background-color: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  box-shadow: 0 20px 40px -34px rgba(0, 0, 0, 0.3);
-}
-
-.groups-page .groups-actions__block {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.groups-page .groups-actions__title {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.groups-page .groups-actions__hint {
-  font-size: 14px;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-.groups-page .groups-divider {
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    180deg,
-    rgba(52, 152, 219, 0) 0%,
-    rgba(52, 152, 219, 0.3) 50%,
-    rgba(52, 152, 219, 0) 100%
-  );
-  align-self: stretch;
-}
 
 @media (max-width: 900px) {
   .groups-page .groups-hero {
@@ -190,14 +149,6 @@
     order: -1;
   }
 
-  .groups-page .groups-divider {
-    display: none;
-  }
-
-  .groups-page .groups-actions {
-    grid-template-columns: 1fr;
-    gap: 20px;
-  }
 }
 
 .groups-page .groups-table-card {

--- a/front/src/pages/Groups.tsx
+++ b/front/src/pages/Groups.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect, useMemo } from 'react'
 import PageTitle from '../components/PageTitle'
 import Table from '../components/Table'
-import GroupInput from '../components/GroupInput'
 import Button from '../components/Button'
-import FileUpload from '../components/FileUpload'
 import { useGroupsStore } from '../stores'
 import { getGroupTableColumns } from '../config/groupTableColumns'
+import GroupsActionsPanel from './Groups/components/GroupsActionsPanel'
 import './Groups.css'
 
 function Groups() {
@@ -106,32 +105,13 @@ function Groups() {
         </aside>
       </section>
 
-      <section className="groups-actions">
-        <div className="groups-actions__block">
-          <h3 className="groups-actions__title">Добавить вручную</h3>
-          <GroupInput
-            url={url}
-            onUrlChange={(e) => setUrl(e.target.value)}
-            onAdd={handleAddGroup}
-          />
-          <p className="groups-actions__hint">
-            Вставьте полный URL сообщества — мы автоматически получим его информацию и добавим в таблицу.
-          </p>
-        </div>
-
-        <div className="groups-divider" aria-hidden="true" />
-
-        <div className="groups-actions__block">
-          <h3 className="groups-actions__title">Импорт из файла</h3>
-          <FileUpload
-            onUpload={handleFileUpload}
-            buttonText="Загрузить из файла"
-          />
-          <p className="groups-actions__hint">
-            Поддерживаются текстовые файлы со ссылками на группы. Каждая ссылка должна быть указана с новой строки.
-          </p>
-        </div>
-      </section>
+      <GroupsActionsPanel
+        onAdd={handleAddGroup}
+        onUpload={handleFileUpload}
+        isLoading={isLoading}
+        url={url}
+        setUrl={setUrl}
+      />
 
       <section className="groups-table-card">
         <div className="groups-table-card__header">

--- a/front/src/pages/Groups/components/GroupsActionsPanel.module.css
+++ b/front/src/pages/Groups/components/GroupsActionsPanel.module.css
@@ -1,0 +1,137 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 32px;
+  border-radius: 22px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  box-shadow: 0 20px 40px -34px rgba(0, 0, 0, 0.3);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-width: 620px;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 1px minmax(0, 1fr);
+  gap: 24px;
+  align-items: stretch;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 24px;
+  border-radius: 18px;
+  border: 1px solid rgba(52, 152, 219, 0.18);
+  background: linear-gradient(135deg, rgba(52, 152, 219, 0.08), rgba(52, 152, 219, 0.02));
+  box-shadow: 0 18px 32px -28px rgba(0, 0, 0, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 48px -28px rgba(52, 152, 219, 0.35);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2c3e50;
+  background: rgba(52, 152, 219, 0.2);
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.cardHint {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.cardHelp {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: rgba(44, 62, 80, 0.75);
+}
+
+.divider {
+  width: 100%;
+  min-height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(52, 152, 219, 0) 0%,
+    rgba(52, 152, 219, 0.35) 50%,
+    rgba(52, 152, 219, 0) 100%
+  );
+}
+
+@media (max-width: 900px) {
+  .content {
+    grid-template-columns: 1fr;
+  }
+
+  .divider {
+    display: none;
+  }
+}
+
+:global(.app.dark-mode) .card {
+  border-color: rgba(93, 173, 226, 0.3);
+  background: linear-gradient(135deg, rgba(93, 173, 226, 0.14), rgba(46, 134, 193, 0.05));
+  box-shadow: 0 24px 48px -32px rgba(93, 173, 226, 0.45);
+}
+
+:global(.app.dark-mode) .card:hover {
+  box-shadow: 0 28px 56px -32px rgba(93, 173, 226, 0.55);
+}
+
+:global(.app.dark-mode) .badge {
+  color: #ecf0f1;
+  background: rgba(93, 173, 226, 0.3);
+}
+
+:global(.app.dark-mode) .cardHelp {
+  color: rgba(236, 240, 241, 0.75);
+}

--- a/front/src/pages/Groups/components/GroupsActionsPanel.tsx
+++ b/front/src/pages/Groups/components/GroupsActionsPanel.tsx
@@ -1,0 +1,72 @@
+import { ChangeEvent, Dispatch, SetStateAction } from 'react'
+import GroupInput from '../../../components/GroupInput'
+import FileUpload from '../../../components/FileUpload'
+import styles from './GroupsActionsPanel.module.css'
+
+interface GroupsActionsPanelProps {
+  onAdd: () => Promise<void> | void
+  onUpload: (event: ChangeEvent<HTMLInputElement>) => Promise<void> | void
+  isLoading: boolean
+  url: string
+  setUrl: Dispatch<SetStateAction<string>>
+}
+
+function GroupsActionsPanel({ onAdd, onUpload, isLoading, url, setUrl }: GroupsActionsPanelProps) {
+  const handleUrlChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setUrl(event.target.value)
+  }
+
+  const handleAdd = () => {
+    void onAdd()
+  }
+
+  return (
+    <section className={styles.panel}>
+      <header className={styles.header}>
+        <h2 className={styles.title}>Добавление новых групп</h2>
+        <p className={styles.subtitle}>
+          Выберите подходящий способ: вставьте ссылку на сообщество или загрузите подготовленный файл.
+          Мы подскажем, что делать дальше.
+        </p>
+      </header>
+
+      <div className={styles.content}>
+        <article className={styles.card}>
+          <div className={styles.cardHeader}>
+            <span className={styles.badge}>Шаг 1</span>
+            <h3 className={styles.cardTitle}>Добавить вручную</h3>
+          </div>
+          <p className={styles.cardHint}>
+            Вставьте URL сообщества ВК — мы проверим ссылку и автоматически добавим группу в список.
+          </p>
+
+          <GroupInput url={url} onUrlChange={handleUrlChange} onAdd={handleAdd} />
+
+          <p className={styles.cardHelp}>
+            Подсказка: можно вставить ссылку из адресной строки браузера. {isLoading && 'Подождите завершения текущей операции.'}
+          </p>
+        </article>
+
+        <div className={styles.divider} aria-hidden="true" />
+
+        <article className={styles.card}>
+          <div className={styles.cardHeader}>
+            <span className={styles.badge}>Шаг 2</span>
+            <h3 className={styles.cardTitle}>Импорт из файла</h3>
+          </div>
+          <p className={styles.cardHint}>
+            Загрузите текстовый файл со ссылками. Каждая ссылка должна находиться на новой строке.
+          </p>
+
+          <FileUpload onUpload={onUpload} buttonText="Загрузить из файла" />
+
+          <p className={styles.cardHelp}>
+            Мы обработаем файл и добавим все найденные сообщества автоматически. {isLoading && 'Импорт может занять некоторое время.'}
+          </p>
+        </article>
+      </div>
+    </section>
+  )
+}
+
+export default GroupsActionsPanel


### PR DESCRIPTION
## Summary
- extract the groups actions markup into a dedicated GroupsActionsPanel component
- scope the actions panel styling with a new CSS module and card layout
- update the Groups page to consume the panel component and drop redundant global styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6015a39e08332a69942fee04d8d0f