### PR TITLE
Добавить шаблоны PR body и commit message для parsevkctl

### DIFF
--- a/docs/PARSEVKCTL.md
+++ b/docs/PARSEVKCTL.md
@@ -118,14 +118,24 @@ clean/dirty state of the working tree. If the issue is not visible in the
 Project, it prints a warning and continues. If no linked PR is found, it prints
 `Linked PR: none`.
 
-The PR command pushes the current branch, creates a pull request with `Closes #66`,
-moves the project card to `Review`, switches back to the configured default branch,
-pulls it with `git pull --ff-only origin <defaultBranch>`, and deletes only the local
-feature branch. If the working tree is not clean after PR creation, the local branch
-is kept and a warning is printed.
+The PR command pushes the current branch, creates a pull request with a structured enterprise-grade body template, moves the project card to `Review`, switches back to the configured default branch, pulls it with `git pull --ff-only origin <defaultBranch>`, and deletes only the local feature branch. If the working tree is not clean after PR creation, the local branch is kept and a warning is printed.
 
-The remote feature branch is intentionally kept while the pull request is open. It is
-deleted only by `task merge` after the PR is merged.
+### PR Body Template
+
+The generated Pull Request uses a deterministic template containing the following sections:
+- **Closing keyword**: `Closes #<issue-number>` at the top.
+- **Summary**: Key highlights of the PR. Custom summary can be specified via `-Summary "..."`. If not provided, defaults to `- <summary or placeholder>`.
+- **Test plan**: Interactive markdown checkboxes. Custom value can be passed via `-TestPlan` (recognized values: `manual` / `automated` / `none`). By default, all checkboxes are unchecked.
+- **Risk**: Risk assessment level. Custom risk can be passed via `-Risk "..."`. Defaults to `Low`.
+- **Notes**: General notes including the `Created via parsevkctl` mark.
+
+Example usage with custom PR body metadata:
+
+```powershell
+.\tools\parsevkctl\parsevkctl.ps1 task pr 66 -Summary "Added csv export feature" -TestPlan "manual" -Risk "Low"
+```
+
+The remote feature branch is intentionally kept while the pull request is open. It is deleted only by `task merge` after the PR is merged.
 
 After review approval, merge the task:
 

--- a/tools/parsevkctl/parsevkctl.Tests.ps1
+++ b/tools/parsevkctl/parsevkctl.Tests.ps1
@@ -750,6 +750,82 @@ Describe "parsevkctl Dry-Run Mode" {
         $joined | Should Match "Would set project status for issue #123 to: Review"
     }
 
+    It "Open-PullRequest with default parameters generates the deterministic PR body template" {
+        $msg = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { param($Object, $ForegroundColor) $msg.Add([string]$Object) }
+
+        $script:SimulatedIssueTitle = "DryRun Test"
+        $script:SimulatedIssueLabel = "type: feat"
+        $script:SimulatedIssueNumber = 123
+
+        Open-PullRequest -IssueNumber 123
+
+        $joined = $msg -join "`n"
+        $joined | Should Match "Closes #123"
+        $joined | Should Match "## Summary\s+-\s+<summary or placeholder>"
+        $joined | Should Match "## Test plan\s+-\s+\[ \]\s+Not run\s+-\s+\[ \]\s+Manual test\s+-\s+\[ \]\s+Automated tests"
+        $joined | Should Match "## Risk\s+-\s+Low"
+        $joined | Should Match "Created via parsevkctl."
+    }
+
+    It "Open-PullRequest with custom Summary parameter uses the summary" {
+        $msg = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { param($Object, $ForegroundColor) $msg.Add([string]$Object) }
+
+        $script:SimulatedIssueTitle = "DryRun Test"
+        $script:SimulatedIssueLabel = "type: feat"
+        $script:SimulatedIssueNumber = 123
+
+        Open-PullRequest -IssueNumber 123 -Summary "Custom issue resolution description"
+
+        $joined = $msg -join "`n"
+        $joined | Should Match "## Summary\s+-\s+Custom issue resolution description"
+    }
+
+    It "Open-PullRequest with custom TestPlan parameter checks correct checkboxes" {
+        $msgManual = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { param($Object, $ForegroundColor) $msgManual.Add([string]$Object) }
+        $script:SimulatedIssueTitle = "DryRun Test"
+        $script:SimulatedIssueLabel = "type: feat"
+        $script:SimulatedIssueNumber = 123
+
+        Open-PullRequest -IssueNumber 123 -TestPlan "manual"
+        $joinedManual = $msgManual -join "`n"
+        $joinedManual | Should Match "-\s+\[ \]\s+Not run"
+        $joinedManual | Should Match "-\s+\[x\]\s+Manual test"
+        $joinedManual | Should Match "-\s+\[ \]\s+Automated tests"
+
+        $msgAutomated = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { param($Object, $ForegroundColor) $msgAutomated.Add([string]$Object) }
+        Open-PullRequest -IssueNumber 123 -TestPlan "automated"
+        $joinedAutomated = $msgAutomated -join "`n"
+        $joinedAutomated | Should Match "-\s+\[ \]\s+Not run"
+        $joinedAutomated | Should Match "-\s+\[ \]\s+Manual test"
+        $joinedAutomated | Should Match "-\s+\[x\]\s+Automated tests"
+
+        $msgNone = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { param($Object, $ForegroundColor) $msgNone.Add([string]$Object) }
+        Open-PullRequest -IssueNumber 123 -TestPlan "none"
+        $joinedNone = $msgNone -join "`n"
+        $joinedNone | Should Match "-\s+\[x\]\s+Not run"
+        $joinedNone | Should Match "-\s+\[ \]\s+Manual test"
+        $joinedNone | Should Match "-\s+\[ \]\s+Automated tests"
+    }
+
+    It "Open-PullRequest with custom Risk parameter uses the risk" {
+        $msg = [System.Collections.Generic.List[string]]::new()
+        Mock Write-Host { param($Object, $ForegroundColor) $msg.Add([string]$Object) }
+
+        $script:SimulatedIssueTitle = "DryRun Test"
+        $script:SimulatedIssueLabel = "type: feat"
+        $script:SimulatedIssueNumber = 123
+
+        Open-PullRequest -IssueNumber 123 -Risk "High"
+
+        $joined = $msg -join "`n"
+        $joined | Should Match "## Risk\s+-\s+High"
+    }
+
     It "Merge-Task in Dry-Run simulates PR and logs squash merge" {
         $msg = [System.Collections.Generic.List[string]]::new()
         Mock Write-Host { param($Object, $ForegroundColor) $msg.Add([string]$Object) }

--- a/tools/parsevkctl/parsevkctl.ps1
+++ b/tools/parsevkctl/parsevkctl.ps1
@@ -15,6 +15,9 @@ param(
     [switch]$NoBranch,
     [switch]$AllowDirty,
     [switch]$DryRun,
+    [string]$Summary = "",
+    [string]$TestPlan = "",
+    [string]$Risk = "",
     [switch]$Json
 )
 
@@ -612,7 +615,12 @@ function Review-Task {
 }
 
 function Open-PullRequest {
-    param([int]$IssueNumber)
+    param(
+        [int]$IssueNumber,
+        [string]$Summary = "",
+        [string]$TestPlan = "",
+        [string]$Risk = ""
+    )
 
     $config = Get-Config
 
@@ -642,9 +650,58 @@ function Open-PullRequest {
     }
 
     $prTitle = $issue.title
+
+    $summaryText = "- <summary or placeholder>"
+    if (-not [string]::IsNullOrWhiteSpace($Summary)) {
+        if ($Summary -match "^[-*]") {
+            $summaryText = $Summary
+        } else {
+            $summaryText = "- $Summary"
+        }
+    }
+
+    $testNotRun = " "
+    $testManual = " "
+    $testAutomated = " "
+    if (-not [string]::IsNullOrWhiteSpace($TestPlan)) {
+        $tpLower = $TestPlan.ToLower().Trim()
+        if ($tpLower -eq "manual" -or $tpLower -eq "manual test") {
+            $testManual = "x"
+        } elseif ($tpLower -eq "automated" -or $tpLower -eq "automated tests" -or $tpLower -eq "auto") {
+            $testAutomated = "x"
+        } elseif ($tpLower -eq "none" -or $tpLower -eq "not run" -or $tpLower -eq "no") {
+            $testNotRun = "x"
+        } else {
+            if ($tpLower -match "auto|unit|pester") {
+                $testAutomated = "x"
+            } elseif ($tpLower -match "none|not|no run") {
+                $testNotRun = "x"
+            } else {
+                $testManual = "x"
+            }
+        }
+    }
+
+    $riskText = "Low"
+    if (-not [string]::IsNullOrWhiteSpace($Risk)) {
+        $riskText = $Risk
+    }
+
     $prBody = @"
 Closes #$IssueNumber
 
+## Summary
+$summaryText
+
+## Test plan
+- [$testNotRun] Not run
+- [$testManual] Manual test
+- [$testAutomated] Automated tests
+
+## Risk
+- $riskText
+
+## Notes
 Created via parsevkctl.
 "@
 
@@ -1525,7 +1582,7 @@ try {
 
         $config = Get-Config
         $issueNumber = [int]$Value
-        $prInfo = Open-PullRequest -IssueNumber $issueNumber
+        $prInfo = Open-PullRequest -IssueNumber $issueNumber -Summary $Summary -TestPlan $TestPlan -Risk $Risk
         
         $result = [PSCustomObject]@{
             command = "task pr"


### PR DESCRIPTION
Closes #82

## Summary
- Улучшен шаблон PR body генерируемый parsevkctl task pr с более детальной структурой (Summary, Test plan, Risk, Notes).

## Test plan
- [ ] Not run
- [ ] Manual test
- [x] Automated tests

## Risk
- Low

## Notes
Created via parsevkctl.