### PR TITLE
Go rewrite: scaffold parsevkctl CLI skeleton

### DIFF
--- a/tools/parsevkctl-go/.gitignore
+++ b/tools/parsevkctl-go/.gitignore
@@ -1,0 +1,1 @@
+﻿parsevkctl.exe

--- a/tools/parsevkctl-go/.gitignore
+++ b/tools/parsevkctl-go/.gitignore
@@ -1,1 +1,2 @@
 parsevkctl.exe
+parsevkctl

--- a/tools/parsevkctl-go/.gitignore
+++ b/tools/parsevkctl-go/.gitignore
@@ -1,1 +1,1 @@
-﻿parsevkctl.exe
+parsevkctl.exe

--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -1,0 +1,7 @@
+﻿# parsevkctl Go CLI
+
+New Go implementation of parsevkctl.
+
+Build: go build ./cmd/parsevkctl
+Test: go test ./...
+Run: go run ./cmd/parsevkctl --help

--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -1,4 +1,4 @@
-﻿# parsevkctl Go CLI
+# parsevkctl Go CLI
 
 New Go implementation of parsevkctl.
 

--- a/tools/parsevkctl-go/cmd/parsevkctl/main.go
+++ b/tools/parsevkctl-go/cmd/parsevkctl/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/cli"
+)
+
+func main() {
+	os.Exit(cli.Run(os.Args[1:], os.Stdout, os.Stderr))
+}

--- a/tools/parsevkctl-go/go.mod
+++ b/tools/parsevkctl-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/andr-235/parseVK/tools/parsevkctl-go
+
+go 1.26

--- a/tools/parsevkctl-go/internal/cli/cli.go
+++ b/tools/parsevkctl-go/internal/cli/cli.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/config"
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/version"
+)
+
+type options struct {
+	configPath string
+	jsonOutput bool
+}
+
+func Run(args []string, stdout io.Writer, stderr io.Writer) int {
+	opts, rest, err := parseGlobalOptions(args)
+	if err != nil {
+		fmt.Fprintln(stderr, "Error:", err)
+		return 2
+	}
+
+	if len(rest) == 0 {
+		printHelp(stdout)
+		return 0
+	}
+
+	switch rest[0] {
+	case "--help", "-h", "help":
+		printHelp(stdout)
+		return 0
+
+	case "--version", "version":
+		fmt.Fprintln(stdout, version.Version)
+		return 0
+
+	case "config":
+		return runConfig(rest[1:], opts, stdout, stderr)
+
+	default:
+		fmt.Fprintf(stderr, "Error: unknown command %q\n\n", rest[0])
+		printHelp(stderr)
+		return 2
+	}
+}
+
+func parseGlobalOptions(args []string) (options, []string, error) {
+	opts := options{}
+	rest := make([]string, 0, len(args))
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--json":
+			opts.jsonOutput = true
+
+		case "--config":
+			if i+1 >= len(args) {
+				return opts, nil, fmt.Errorf("--config requires a path")
+			}
+			opts.configPath = args[i+1]
+			i++
+
+		default:
+			rest = append(rest, args[i])
+		}
+	}
+
+	return opts, rest, nil
+}
+
+func runConfig(args []string, opts options, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "Error: config command requires a subcommand")
+		fmt.Fprintln(stderr, "Usage: parsevkctl config validate [--config <path>] [--json]")
+		return 2
+	}
+
+	switch args[0] {
+	case "validate":
+		result := config.ValidateFile(opts.configPath)
+
+		if opts.jsonOutput {
+			encoded, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				fmt.Fprintln(stderr, "Error: failed to render JSON:", err)
+				return 1
+			}
+			fmt.Fprintln(stdout, string(encoded))
+		} else {
+			printConfigValidation(stdout, result)
+		}
+
+		if !result.Valid {
+			return 1
+		}
+
+		return 0
+
+	default:
+		fmt.Fprintf(stderr, "Error: unknown config subcommand %q\n", args[0])
+		return 2
+	}
+}
+
+func printConfigValidation(w io.Writer, result config.ValidationResult) {
+	fmt.Fprintln(w, "parsevkctl config validate")
+	fmt.Fprintln(w, "Path:", result.Path)
+
+	if result.Valid {
+		fmt.Fprintln(w, "Result: VALID")
+		return
+	}
+
+	fmt.Fprintln(w, "Result: INVALID")
+	for _, err := range result.Errors {
+		fmt.Fprintln(w, "-", err)
+	}
+}
+
+func printHelp(w io.Writer) {
+	fmt.Fprintln(w, `parsevkctl
+
+Usage:
+  parsevkctl --help
+  parsevkctl --version
+  parsevkctl config validate [--config <path>] [--json]
+
+Commands:
+  config validate   Validate parsevkctl config without GitHub or git side effects
+
+Global flags:
+  --config <path>   Path to config.json
+  --json            Render machine-readable JSON output`)
+}

--- a/tools/parsevkctl-go/internal/config/config.go
+++ b/tools/parsevkctl-go/internal/config/config.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Config struct {
+	Repo          string        `json:"repo"`
+	DefaultBranch string        `json:"defaultBranch"`
+	ProjectOwner  string        `json:"projectOwner"`
+	ProjectNumber any           `json:"projectNumber"`
+	ProjectID     string        `json:"projectId"`
+	ProjectTitle  string        `json:"projectTitle"`
+	Statuses      Statuses      `json:"statuses"`
+	Merge         MergeSettings `json:"merge"`
+}
+
+type Statuses struct {
+	Todo       string `json:"todo"`
+	InProgress string `json:"inProgress"`
+	Review     string `json:"review"`
+	Done       string `json:"done"`
+}
+
+type MergeSettings struct {
+	RequireChecks  bool `json:"requireChecks"`
+	AllowAutoMerge bool `json:"allowAutoMerge"`
+}
+
+type ValidationResult struct {
+	Path   string   `json:"path"`
+	Valid  bool     `json:"valid"`
+	Errors []string `json:"errors,omitempty"`
+}
+
+func DefaultPaths() []string {
+	return []string{
+		filepath.Join("tools", "parsevkctl", "config.json"),
+		filepath.Join(".tools", "parsevkctl", "config.json"),
+		filepath.Join("..", "parsevkctl", "config.json"),
+	}
+}
+
+func ResolvePath(explicitPath string) (string, error) {
+	if strings.TrimSpace(explicitPath) != "" {
+		if _, err := os.Stat(explicitPath); err != nil {
+			return explicitPath, err
+		}
+		return explicitPath, nil
+	}
+
+	for _, candidate := range DefaultPaths() {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", errors.New("config not found; pass --config <path> or create tools/parsevkctl/config.json")
+}
+
+func Load(path string) (Config, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return Config{}, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func Validate(cfg Config) []string {
+	var errs []string
+
+	require := func(name string, value string) {
+		if strings.TrimSpace(value) == "" {
+			errs = append(errs, "missing field "+name)
+		}
+	}
+
+	require("repo", cfg.Repo)
+	require("defaultBranch", cfg.DefaultBranch)
+	require("projectOwner", cfg.ProjectOwner)
+	require("projectId", cfg.ProjectID)
+	require("projectTitle", cfg.ProjectTitle)
+
+	if cfg.ProjectNumber == nil {
+		errs = append(errs, "missing field projectNumber")
+	}
+
+	if strings.TrimSpace(cfg.Repo) != "" {
+		parts := strings.Split(cfg.Repo, "/")
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+			errs = append(errs, "repo must use owner/name format")
+		}
+	}
+
+	require("statuses.todo", cfg.Statuses.Todo)
+	require("statuses.inProgress", cfg.Statuses.InProgress)
+	require("statuses.review", cfg.Statuses.Review)
+	require("statuses.done", cfg.Statuses.Done)
+
+	return errs
+}
+
+func ValidateFile(explicitPath string) ValidationResult {
+	path, err := ResolvePath(explicitPath)
+	if err != nil {
+		return ValidationResult{
+			Path:   explicitPath,
+			Valid:  false,
+			Errors: []string{err.Error()},
+		}
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		return ValidationResult{
+			Path:   path,
+			Valid:  false,
+			Errors: []string{err.Error()},
+		}
+	}
+
+	errs := Validate(cfg)
+
+	return ValidationResult{
+		Path:   path,
+		Valid:  len(errs) == 0,
+		Errors: errs,
+	}
+}

--- a/tools/parsevkctl-go/internal/config/config.go
+++ b/tools/parsevkctl-go/internal/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	Repo          string        `json:"repo"`
 	DefaultBranch string        `json:"defaultBranch"`
 	ProjectOwner  string        `json:"projectOwner"`
-	ProjectNumber any           `json:"projectNumber"`
+	ProjectNumber int           `json:"projectNumber"`
 	ProjectID     string        `json:"projectId"`
 	ProjectTitle  string        `json:"projectTitle"`
 	Statuses      Statuses      `json:"statuses"`
@@ -28,8 +28,8 @@ type Statuses struct {
 }
 
 type MergeSettings struct {
-	RequireChecks  bool `json:"requireChecks"`
-	AllowAutoMerge bool `json:"allowAutoMerge"`
+	RequireChecks  *bool `json:"requireChecks"`
+	AllowAutoMerge *bool `json:"allowAutoMerge"`
 }
 
 type ValidationResult struct {
@@ -92,8 +92,8 @@ func Validate(cfg Config) []string {
 	require("projectId", cfg.ProjectID)
 	require("projectTitle", cfg.ProjectTitle)
 
-	if cfg.ProjectNumber == nil {
-		errs = append(errs, "missing field projectNumber")
+	if cfg.ProjectNumber <= 0 {
+		errs = append(errs, "projectNumber must be a positive integer")
 	}
 
 	if strings.TrimSpace(cfg.Repo) != "" {
@@ -107,6 +107,13 @@ func Validate(cfg Config) []string {
 	require("statuses.inProgress", cfg.Statuses.InProgress)
 	require("statuses.review", cfg.Statuses.Review)
 	require("statuses.done", cfg.Statuses.Done)
+
+	if cfg.Merge.RequireChecks == nil {
+		errs = append(errs, "missing field merge.requireChecks")
+	}
+	if cfg.Merge.AllowAutoMerge == nil {
+		errs = append(errs, "missing field merge.allowAutoMerge")
+	}
 
 	return errs
 }

--- a/tools/parsevkctl-go/internal/config/config_test.go
+++ b/tools/parsevkctl-go/internal/config/config_test.go
@@ -1,0 +1,84 @@
+package config
+
+import "testing"
+
+func TestValidateAcceptsValidConfig(t *testing.T) {
+	cfg := Config{
+		Repo:          "andr-235/parseVK",
+		DefaultBranch: "fastapi-microservices-rewrite",
+		ProjectOwner:  "andr-235",
+		ProjectNumber: float64(1),
+		ProjectID:     "PVT_kw_TEST",
+		ProjectTitle:  "parseVK",
+		Statuses: Statuses{
+			Todo:       "Todo",
+			InProgress: "In Progress",
+			Review:     "Review",
+			Done:       "Done",
+		},
+		Merge: MergeSettings{
+			RequireChecks:  false,
+			AllowAutoMerge: false,
+		},
+	}
+
+	errs := Validate(cfg)
+	if len(errs) != 0 {
+		t.Fatalf("expected valid config, got errors: %v", errs)
+	}
+}
+
+func TestValidateRejectsBadRepoFormat(t *testing.T) {
+	cfg := Config{
+		Repo:          "parseVK",
+		DefaultBranch: "main",
+		ProjectOwner:  "andr-235",
+		ProjectNumber: float64(1),
+		ProjectID:     "PVT_kw_TEST",
+		ProjectTitle:  "parseVK",
+		Statuses: Statuses{
+			Todo:       "Todo",
+			InProgress: "In Progress",
+			Review:     "Review",
+			Done:       "Done",
+		},
+	}
+
+	errs := Validate(cfg)
+
+	if !contains(errs, "repo must use owner/name format") {
+		t.Fatalf("expected repo format error, got: %v", errs)
+	}
+}
+
+func TestValidateRejectsMissingStatus(t *testing.T) {
+	cfg := Config{
+		Repo:          "andr-235/parseVK",
+		DefaultBranch: "main",
+		ProjectOwner:  "andr-235",
+		ProjectNumber: float64(1),
+		ProjectID:     "PVT_kw_TEST",
+		ProjectTitle:  "parseVK",
+		Statuses: Statuses{
+			Todo:       "Todo",
+			InProgress: "In Progress",
+			Done:       "Done",
+		},
+	}
+
+	errs := Validate(cfg)
+
+	if !contains(errs, "missing field statuses.review") {
+		t.Fatalf("expected missing review status error, got: %v", errs)
+	}
+}
+
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tools/parsevkctl-go/internal/config/config_test.go
+++ b/tools/parsevkctl-go/internal/config/config_test.go
@@ -7,7 +7,7 @@ func TestValidateAcceptsValidConfig(t *testing.T) {
 		Repo:          "andr-235/parseVK",
 		DefaultBranch: "fastapi-microservices-rewrite",
 		ProjectOwner:  "andr-235",
-		ProjectNumber: float64(1),
+		ProjectNumber: 1,
 		ProjectID:     "PVT_kw_TEST",
 		ProjectTitle:  "parseVK",
 		Statuses: Statuses{
@@ -17,8 +17,8 @@ func TestValidateAcceptsValidConfig(t *testing.T) {
 			Done:       "Done",
 		},
 		Merge: MergeSettings{
-			RequireChecks:  false,
-			AllowAutoMerge: false,
+			RequireChecks:  boolPtr(false),
+			AllowAutoMerge: boolPtr(false),
 		},
 	}
 
@@ -33,7 +33,7 @@ func TestValidateRejectsBadRepoFormat(t *testing.T) {
 		Repo:          "parseVK",
 		DefaultBranch: "main",
 		ProjectOwner:  "andr-235",
-		ProjectNumber: float64(1),
+		ProjectNumber: 1,
 		ProjectID:     "PVT_kw_TEST",
 		ProjectTitle:  "parseVK",
 		Statuses: Statuses{
@@ -56,7 +56,7 @@ func TestValidateRejectsMissingStatus(t *testing.T) {
 		Repo:          "andr-235/parseVK",
 		DefaultBranch: "main",
 		ProjectOwner:  "andr-235",
-		ProjectNumber: float64(1),
+		ProjectNumber: 1,
 		ProjectID:     "PVT_kw_TEST",
 		ProjectTitle:  "parseVK",
 		Statuses: Statuses{
@@ -81,4 +81,32 @@ func contains(values []string, expected string) bool {
 	}
 
 	return false
+}
+
+func boolPtr(value bool) *bool { return &value }
+
+func TestValidateRejectsMissingMergeFlags(t *testing.T) {
+	cfg := Config{
+		Repo:          "andr-235/parseVK",
+		DefaultBranch: "main",
+		ProjectOwner:  "andr-235",
+		ProjectNumber: 1,
+		ProjectID:     "PVT_kw_TEST",
+		ProjectTitle:  "parseVK",
+		Statuses: Statuses{
+			Todo:       "Todo",
+			InProgress: "In Progress",
+			Review:     "Review",
+			Done:       "Done",
+		},
+	}
+
+	errs := Validate(cfg)
+
+	if !contains(errs, "missing field merge.requireChecks") {
+		t.Fatalf("expected missing requireChecks error, got: %v", errs)
+	}
+	if !contains(errs, "missing field merge.allowAutoMerge") {
+		t.Fatalf("expected missing allowAutoMerge error, got: %v", errs)
+	}
 }

--- a/tools/parsevkctl-go/internal/version/version.go
+++ b/tools/parsevkctl-go/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const Version = "0.1.0-dev"


### PR DESCRIPTION
Closes #104

## Summary
- Added initial Go module for parsevkctl under tools/parsevkctl-go
- Added CLI skeleton with help, version and config validate
- Added typed config validation and unit tests
- Added basic README and gitignore for local build artifact

## Test plan
- go test ./...
- go build ./cmd/parsevkctl
- go run ./cmd/parsevkctl --help
- go run ./cmd/parsevkctl --version
- go run ./cmd/parsevkctl config validate
- go run ./cmd/parsevkctl --json config validate

## Risk
- Low

## Notes
PowerShell implementation remains unchanged during migration.