### PR TITLE
Go rewrite: strengthen typed config validation

### DIFF
--- a/tools/parsevkctl-go/internal/config/config.go
+++ b/tools/parsevkctl-go/internal/config/config.go
@@ -32,10 +32,16 @@ type MergeSettings struct {
 	AllowAutoMerge *bool `json:"allowAutoMerge"`
 }
 
+type ValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
 type ValidationResult struct {
-	Path   string   `json:"path"`
-	Valid  bool     `json:"valid"`
-	Errors []string `json:"errors,omitempty"`
+	Path             string            `json:"path"`
+	Valid            bool              `json:"valid"`
+	Errors           []string          `json:"errors,omitempty"`
+	ValidationErrors []ValidationError `json:"validationErrors,omitempty"`
 }
 
 func DefaultPaths() []string {
@@ -140,8 +146,31 @@ func ValidateFile(explicitPath string) ValidationResult {
 	errs := Validate(cfg)
 
 	return ValidationResult{
-		Path:   path,
-		Valid:  len(errs) == 0,
-		Errors: errs,
+		Path:             path,
+		Valid:            len(errs) == 0,
+		Errors:           errs,
+		ValidationErrors: toValidationErrors(errs),
 	}
+}
+
+func toValidationErrors(errors []string) []ValidationError {
+	result := make([]ValidationError, 0, len(errors))
+
+	for _, message := range errors {
+		field := ""
+		if after, ok := strings.CutPrefix(message, "missing field "); ok {
+			field = after
+		} else if strings.HasPrefix(message, "projectNumber ") {
+			field = "projectNumber"
+		} else if strings.HasPrefix(message, "repo ") {
+			field = "repo"
+		}
+
+		result = append(result, ValidationError{
+			Field:   field,
+			Message: message,
+		})
+	}
+
+	return result
 }

--- a/tools/parsevkctl-go/internal/config/config_test.go
+++ b/tools/parsevkctl-go/internal/config/config_test.go
@@ -230,3 +230,121 @@ func TestValidateFileRejectsMissingExplicitPath(t *testing.T) {
 		t.Fatalf("expected missing path error")
 	}
 }
+
+func TestValidateRejectsMissingRequiredFields(t *testing.T) {
+	valid := Config{
+		Repo:          "andr-235/parseVK",
+		DefaultBranch: "main",
+		ProjectOwner:  "andr-235",
+		ProjectNumber: 1,
+		ProjectID:     "PVT_kw_TEST",
+		ProjectTitle:  "parseVK",
+		Statuses: Statuses{
+			Todo:       "Todo",
+			InProgress: "In Progress",
+			Review:     "Review",
+			Done:       "Done",
+		},
+		Merge: MergeSettings{
+			RequireChecks:  boolPtr(false),
+			AllowAutoMerge: boolPtr(false),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		mutate        func(*Config)
+		expectedError string
+	}{
+		{
+			name: "missing repo",
+			mutate: func(cfg *Config) {
+				cfg.Repo = ""
+			},
+			expectedError: "missing field repo",
+		},
+		{
+			name: "missing defaultBranch",
+			mutate: func(cfg *Config) {
+				cfg.DefaultBranch = ""
+			},
+			expectedError: "missing field defaultBranch",
+		},
+		{
+			name: "missing projectOwner",
+			mutate: func(cfg *Config) {
+				cfg.ProjectOwner = ""
+			},
+			expectedError: "missing field projectOwner",
+		},
+		{
+			name: "missing projectId",
+			mutate: func(cfg *Config) {
+				cfg.ProjectID = ""
+			},
+			expectedError: "missing field projectId",
+		},
+		{
+			name: "missing projectTitle",
+			mutate: func(cfg *Config) {
+				cfg.ProjectTitle = ""
+			},
+			expectedError: "missing field projectTitle",
+		},
+		{
+			name: "missing projectNumber",
+			mutate: func(cfg *Config) {
+				cfg.ProjectNumber = 0
+			},
+			expectedError: "projectNumber must be a positive integer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := valid
+			tt.mutate(&cfg)
+
+			errs := Validate(cfg)
+			if !contains(errs, tt.expectedError) {
+				t.Fatalf("expected %q, got: %v", tt.expectedError, errs)
+			}
+		})
+	}
+}
+
+func TestValidateFileReturnsStructuredValidationErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	raw := []byte(`{
+"repo": "parseVK",
+"defaultBranch": "main",
+"projectOwner": "andr-235",
+"projectNumber": 0,
+"projectId": "PVT_kw_TEST",
+"projectTitle": "parseVK",
+"statuses": {
+"todo": "Todo",
+"inProgress": "In Progress",
+"review": "Review",
+"done": "Done"
+},
+"merge": {
+"requireChecks": false,
+"allowAutoMerge": false
+}
+}`)
+
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := ValidateFile(path)
+	if result.Valid {
+		t.Fatalf("expected invalid config")
+	}
+	if len(result.ValidationErrors) == 0 {
+		t.Fatalf("expected structured validation errors")
+	}
+}

--- a/tools/parsevkctl-go/internal/config/config_test.go
+++ b/tools/parsevkctl-go/internal/config/config_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestValidateAcceptsValidConfig(t *testing.T) {
 	cfg := Config{
@@ -108,5 +112,121 @@ func TestValidateRejectsMissingMergeFlags(t *testing.T) {
 	}
 	if !contains(errs, "missing field merge.allowAutoMerge") {
 		t.Fatalf("expected missing allowAutoMerge error, got: %v", errs)
+	}
+}
+
+func TestValidateFileAcceptsValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	raw := []byte(`{
+"repo": "andr-235/parseVK",
+"defaultBranch": "fastapi-microservices-rewrite",
+"projectOwner": "andr-235",
+"projectNumber": 1,
+"projectId": "PVT_kw_TEST",
+"projectTitle": "parseVK",
+"statuses": {
+"todo": "Todo",
+"inProgress": "In Progress",
+"review": "Review",
+"done": "Done"
+},
+"merge": {
+"requireChecks": false,
+"allowAutoMerge": false
+}
+}`)
+
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := ValidateFile(path)
+	if !result.Valid {
+		t.Fatalf("expected valid config file, got: %v", result.Errors)
+	}
+}
+
+func TestValidateFileRejectsInvalidProjectNumberType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	raw := []byte(`{
+"repo": "andr-235/parseVK",
+"defaultBranch": "main",
+"projectOwner": "andr-235",
+"projectNumber": "one",
+"projectId": "PVT_kw_TEST",
+"projectTitle": "parseVK",
+"statuses": {
+"todo": "Todo",
+"inProgress": "In Progress",
+"review": "Review",
+"done": "Done"
+},
+"merge": {
+"requireChecks": false,
+"allowAutoMerge": false
+}
+}`)
+
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := ValidateFile(path)
+	if result.Valid {
+		t.Fatalf("expected invalid config")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatalf("expected validation errors")
+	}
+}
+
+func TestValidateFileRejectsMissingMergeFlags(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	raw := []byte(`{
+"repo": "andr-235/parseVK",
+"defaultBranch": "main",
+"projectOwner": "andr-235",
+"projectNumber": 1,
+"projectId": "PVT_kw_TEST",
+"projectTitle": "parseVK",
+"statuses": {
+"todo": "Todo",
+"inProgress": "In Progress",
+"review": "Review",
+"done": "Done"
+}
+}`)
+
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := ValidateFile(path)
+	if result.Valid {
+		t.Fatalf("expected invalid config")
+	}
+	if !contains(result.Errors, "missing field merge.requireChecks") {
+		t.Fatalf("expected missing requireChecks error, got: %v", result.Errors)
+	}
+	if !contains(result.Errors, "missing field merge.allowAutoMerge") {
+		t.Fatalf("expected missing allowAutoMerge error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateFileRejectsMissingExplicitPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.json")
+
+	result := ValidateFile(path)
+	if result.Valid {
+		t.Fatalf("expected invalid config")
+	}
+	if len(result.Errors) == 0 {
+		t.Fatalf("expected missing path error")
 	}
 }


### PR DESCRIPTION
Closes #105

## Summary
- Added structured validation errors for Go config validation results
- Added file-level tests for valid JSON config loading
- Covered invalid projectNumber type handling
- Covered missing required config fields
- Covered missing merge flags
- Covered missing explicit config path handling

## Test plan
- go test ./...
- go run ./cmd/parsevkctl config validate
- go run ./cmd/parsevkctl --json config validate

## Risk
- Low

## Notes
Config validation remains independent from GitHub and git adapters.