### PR TITLE
Go rewrite: define parsevkctl domain model

### DIFF
--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -5,3 +5,7 @@ New Go implementation of parsevkctl.
 Build: go build ./cmd/parsevkctl
 Test: go test ./...
 Run: go run ./cmd/parsevkctl --help
+
+## Domain model
+
+`internal/domain` contains pure Go types for tasks, issues, pull requests, project items and lifecycle state. It also owns validation helpers and task state derivation logic, without dependencies on the CLI, Git, GitHub, Project adapters or output rendering.

--- a/tools/parsevkctl-go/internal/domain/domain.go
+++ b/tools/parsevkctl-go/internal/domain/domain.go
@@ -1,0 +1,153 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+)
+
+type TaskID int
+
+type BranchName string
+
+type IssueState string
+
+const (
+	IssueStateUnknown IssueState = "Unknown"
+	IssueStateOpen    IssueState = "Open"
+	IssueStateClosed  IssueState = "Closed"
+)
+
+type Issue struct {
+	ID     TaskID
+	Title  string
+	State  IssueState
+	Branch BranchName
+}
+
+type PullRequestState string
+
+const (
+	PullRequestStateNone   PullRequestState = "None"
+	PullRequestStateOpen   PullRequestState = "Open"
+	PullRequestStateClosed PullRequestState = "Closed"
+	PullRequestStateMerged PullRequestState = "Merged"
+	PullRequestStateDraft  PullRequestState = "Draft"
+)
+
+type PullRequest struct {
+	Number TaskID
+	Title  string
+	State  PullRequestState
+	Draft  bool
+	Merged bool
+}
+
+type ProjectStatus string
+
+const (
+	ProjectStatusUnknown    ProjectStatus = "Unknown"
+	ProjectStatusTodo       ProjectStatus = "Todo"
+	ProjectStatusInProgress ProjectStatus = "In Progress"
+	ProjectStatusReview     ProjectStatus = "Review"
+	ProjectStatusDone       ProjectStatus = "Done"
+)
+
+type ProjectItem struct {
+	ID     string
+	Status ProjectStatus
+}
+
+type TaskState string
+
+const (
+	TaskStateUntracked  TaskState = "Untracked"
+	TaskStateTodo       TaskState = "Todo"
+	TaskStateInProgress TaskState = "InProgress"
+	TaskStateReview     TaskState = "Review"
+	TaskStateMerged     TaskState = "Merged"
+	TaskStateDone       TaskState = "Done"
+	TaskStateBlocked    TaskState = "Blocked"
+	TaskStateInvalid    TaskState = "Invalid"
+)
+
+type CommandResult struct {
+	OK      bool
+	Message string
+}
+
+type TaskSnapshot struct {
+	HasIssue          bool
+	IssueState        IssueState
+	ProjectStatus     ProjectStatus
+	PullRequestState  PullRequestState
+	PullRequestDraft  bool
+	PullRequestMerged bool
+}
+
+func ValidateTaskID(id TaskID) error {
+	if id <= 0 {
+		return errors.New("task ID must be a positive integer")
+	}
+
+	return nil
+}
+
+func ValidateBranchName(name BranchName) error {
+	if strings.TrimSpace(string(name)) == "" {
+		return errors.New("branch name must not be empty")
+	}
+
+	return nil
+}
+
+func NormalizeProjectStatus(value string) ProjectStatus {
+	normalized := strings.ToLower(strings.Join(strings.Fields(value), " "))
+
+	switch normalized {
+	case "todo":
+		return ProjectStatusTodo
+	case "in progress":
+		return ProjectStatusInProgress
+	case "review":
+		return ProjectStatusReview
+	case "done":
+		return ProjectStatusDone
+	default:
+		return ProjectStatusUnknown
+	}
+}
+
+func DeriveTaskState(snapshot TaskSnapshot) TaskState {
+	if !snapshot.HasIssue {
+		return TaskStateUntracked
+	}
+
+	if snapshot.IssueState == IssueStateClosed {
+		return TaskStateDone
+	}
+
+	if snapshot.PullRequestMerged || snapshot.PullRequestState == PullRequestStateMerged {
+		return TaskStateMerged
+	}
+
+	if snapshot.PullRequestDraft || snapshot.PullRequestState == PullRequestStateDraft {
+		return TaskStateReview
+	}
+
+	if snapshot.PullRequestState == PullRequestStateOpen {
+		return TaskStateReview
+	}
+
+	switch snapshot.ProjectStatus {
+	case ProjectStatusInProgress:
+		return TaskStateInProgress
+	case ProjectStatusReview:
+		return TaskStateReview
+	case ProjectStatusDone:
+		return TaskStateDone
+	case ProjectStatusTodo:
+		return TaskStateTodo
+	default:
+		return TaskStateInvalid
+	}
+}

--- a/tools/parsevkctl-go/internal/domain/domain_test.go
+++ b/tools/parsevkctl-go/internal/domain/domain_test.go
@@ -1,0 +1,127 @@
+package domain
+
+import "testing"
+
+func TestValidateTaskIDAcceptsPositiveID(t *testing.T) {
+	if err := ValidateTaskID(TaskID(106)); err != nil {
+		t.Fatalf("expected valid task ID, got: %v", err)
+	}
+}
+
+func TestValidateTaskIDRejectsZeroAndNegativeIDs(t *testing.T) {
+	tests := []TaskID{0, -1}
+
+	for _, id := range tests {
+		if err := ValidateTaskID(id); err == nil {
+			t.Fatalf("expected invalid task ID %d", id)
+		}
+	}
+}
+
+func TestValidateBranchNameRejectsEmptyBranch(t *testing.T) {
+	tests := []BranchName{"", "   "}
+
+	for _, name := range tests {
+		if err := ValidateBranchName(name); err == nil {
+			t.Fatalf("expected invalid branch name %q", name)
+		}
+	}
+}
+
+func TestNormalizeProjectStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected ProjectStatus
+	}{
+		{name: "todo", value: " todo ", expected: ProjectStatusTodo},
+		{name: "in progress", value: "in   progress", expected: ProjectStatusInProgress},
+		{name: "review", value: "REVIEW", expected: ProjectStatusReview},
+		{name: "done", value: "Done", expected: ProjectStatusDone},
+		{name: "unknown", value: "Backlog", expected: ProjectStatusUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeProjectStatus(tt.value)
+			if got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestDeriveTaskStateFromTodoProjectStatus(t *testing.T) {
+	got := DeriveTaskState(TaskSnapshot{
+		HasIssue:      true,
+		IssueState:    IssueStateOpen,
+		ProjectStatus: ProjectStatusTodo,
+	})
+
+	if got != TaskStateTodo {
+		t.Fatalf("expected %q, got %q", TaskStateTodo, got)
+	}
+}
+
+func TestDeriveTaskStateFromInProgressProjectStatus(t *testing.T) {
+	got := DeriveTaskState(TaskSnapshot{
+		HasIssue:      true,
+		IssueState:    IssueStateOpen,
+		ProjectStatus: ProjectStatusInProgress,
+	})
+
+	if got != TaskStateInProgress {
+		t.Fatalf("expected %q, got %q", TaskStateInProgress, got)
+	}
+}
+
+func TestDeriveTaskStateFromOpenPullRequest(t *testing.T) {
+	got := DeriveTaskState(TaskSnapshot{
+		HasIssue:         true,
+		IssueState:       IssueStateOpen,
+		PullRequestState: PullRequestStateOpen,
+		ProjectStatus:    ProjectStatusTodo,
+	})
+
+	if got != TaskStateReview {
+		t.Fatalf("expected %q, got %q", TaskStateReview, got)
+	}
+}
+
+func TestDeriveTaskStateFromMergedPullRequest(t *testing.T) {
+	got := DeriveTaskState(TaskSnapshot{
+		HasIssue:          true,
+		IssueState:        IssueStateOpen,
+		PullRequestState:  PullRequestStateMerged,
+		PullRequestMerged: true,
+		ProjectStatus:     ProjectStatusReview,
+	})
+
+	if got != TaskStateMerged {
+		t.Fatalf("expected %q, got %q", TaskStateMerged, got)
+	}
+}
+
+func TestDeriveTaskStateFromClosedIssue(t *testing.T) {
+	got := DeriveTaskState(TaskSnapshot{
+		HasIssue:      true,
+		IssueState:    IssueStateClosed,
+		ProjectStatus: ProjectStatusReview,
+	})
+
+	if got != TaskStateDone {
+		t.Fatalf("expected %q, got %q", TaskStateDone, got)
+	}
+}
+
+func TestDeriveTaskStateFallsBackToInvalidForUnknownState(t *testing.T) {
+	got := DeriveTaskState(TaskSnapshot{
+		HasIssue:      true,
+		IssueState:    IssueStateOpen,
+		ProjectStatus: ProjectStatusUnknown,
+	})
+
+	if got != TaskStateInvalid {
+		t.Fatalf("expected %q, got %q", TaskStateInvalid, got)
+	}
+}


### PR DESCRIPTION
Closes #106

## Summary
- Add pure Go domain types and task state derivation for parsevkctl.

## Test plan
- [ ] Not run
- [ ] Manual test
- [x] Automated tests

## Risk
- Low

## Notes
Created via parsevkctl.