### PR TITLE
Go rewrite: add Git adapter

### DIFF
--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -9,3 +9,7 @@ Run: go run ./cmd/parsevkctl --help
 ## Domain model
 
 `internal/domain` contains pure Go types for tasks, issues, pull requests, project items and lifecycle state. It also owns validation helpers and task state derivation logic, without dependencies on the CLI, Git, GitHub, Project adapters or output rendering.
+
+## Git adapter
+
+`internal/git` centralizes local Git operations for the Go rewrite. It exposes an adapter interface for repository actions and currently implements it with a shell-based adapter that calls `git` directly.

--- a/tools/parsevkctl-go/internal/git/errors.go
+++ b/tools/parsevkctl-go/internal/git/errors.go
@@ -1,0 +1,32 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+type CommandError struct {
+	Operation string
+	Stdout    string
+	Stderr    string
+	Err       error
+}
+
+func (err CommandError) Error() string {
+	parts := []string{fmt.Sprintf("git %s failed", err.Operation)}
+	if err.Err != nil {
+		parts = append(parts, err.Err.Error())
+	}
+	if strings.TrimSpace(err.Stderr) != "" {
+		parts = append(parts, "stderr: "+err.Stderr)
+	}
+	if strings.TrimSpace(err.Stdout) != "" {
+		parts = append(parts, "stdout: "+err.Stdout)
+	}
+
+	return strings.Join(parts, ": ")
+}
+
+func (err CommandError) Unwrap() error {
+	return err.Err
+}

--- a/tools/parsevkctl-go/internal/git/git.go
+++ b/tools/parsevkctl-go/internal/git/git.go
@@ -1,0 +1,15 @@
+package git
+
+import "context"
+
+type Adapter interface {
+	CurrentBranch(ctx context.Context) (string, error)
+	IsWorkTreeClean(ctx context.Context) (bool, []string, error)
+	Fetch(ctx context.Context, remote string, branch string) error
+	Switch(ctx context.Context, branch string) error
+	PullFFOnly(ctx context.Context, remote string, branch string) error
+	CreateBranch(ctx context.Context, branch string) error
+	DeleteLocalBranch(ctx context.Context, branch string, force bool) error
+	PushBranch(ctx context.Context, remote string, branch string, setUpstream bool) error
+	HasCommitsAhead(ctx context.Context, base string, head string) (bool, error)
+}

--- a/tools/parsevkctl-go/internal/git/shell.go
+++ b/tools/parsevkctl-go/internal/git/shell.go
@@ -1,0 +1,215 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+var protectedBranches = map[string]struct{}{
+	"main":                          {},
+	"master":                        {},
+	"fastapi-microservices-rewrite": {},
+}
+
+type commandResult struct {
+	stdout string
+	stderr string
+}
+
+type commandRunner func(ctx context.Context, name string, args ...string) (commandResult, error)
+
+type ShellAdapter struct {
+	gitPath string
+	runner  commandRunner
+}
+
+func NewShellAdapter() *ShellAdapter {
+	return newShellAdapterWithRunner(runCommand)
+}
+
+func newShellAdapterWithRunner(runner commandRunner) *ShellAdapter {
+	return &ShellAdapter{
+		gitPath: "git",
+		runner:  runner,
+	}
+}
+
+func (adapter *ShellAdapter) CurrentBranch(ctx context.Context) (string, error) {
+	result, err := adapter.runGit(ctx, "current branch", "branch", "--show-current")
+	if err != nil {
+		return "", err
+	}
+
+	return result.stdout, nil
+}
+
+func (adapter *ShellAdapter) IsWorkTreeClean(ctx context.Context) (bool, []string, error) {
+	result, err := adapter.runGit(ctx, "status", "status", "--short")
+	if err != nil {
+		return false, nil, err
+	}
+
+	clean, files := parseStatusOutput(result.stdout)
+	return clean, files, nil
+}
+
+func (adapter *ShellAdapter) Fetch(ctx context.Context, remote string, branch string) error {
+	if err := validateRemoteAndBranch(remote, branch); err != nil {
+		return err
+	}
+
+	_, err := adapter.runGit(ctx, "fetch", "fetch", remote, branch)
+	return err
+}
+
+func (adapter *ShellAdapter) Switch(ctx context.Context, branch string) error {
+	if err := validateBranch(branch); err != nil {
+		return err
+	}
+
+	_, err := adapter.runGit(ctx, "switch", "switch", branch)
+	return err
+}
+
+func (adapter *ShellAdapter) PullFFOnly(ctx context.Context, remote string, branch string) error {
+	if err := validateRemoteAndBranch(remote, branch); err != nil {
+		return err
+	}
+
+	_, err := adapter.runGit(ctx, "pull --ff-only", "pull", "--ff-only", remote, branch)
+	return err
+}
+
+func (adapter *ShellAdapter) CreateBranch(ctx context.Context, branch string) error {
+	if err := validateBranch(branch); err != nil {
+		return err
+	}
+
+	_, err := adapter.runGit(ctx, "create branch", "switch", "-c", branch)
+	return err
+}
+
+func (adapter *ShellAdapter) DeleteLocalBranch(ctx context.Context, branch string, force bool) error {
+	if err := validateBranch(branch); err != nil {
+		return err
+	}
+	if isProtectedBranch(branch) {
+		return fmt.Errorf("refusing to delete protected branch %q", strings.TrimSpace(branch))
+	}
+
+	deleteFlag := "-d"
+	if force {
+		deleteFlag = "-D"
+	}
+
+	_, err := adapter.runGit(ctx, "delete local branch", "branch", deleteFlag, branch)
+	return err
+}
+
+func (adapter *ShellAdapter) PushBranch(ctx context.Context, remote string, branch string, setUpstream bool) error {
+	if err := validateRemoteAndBranch(remote, branch); err != nil {
+		return err
+	}
+
+	args := []string{"push"}
+	if setUpstream {
+		args = append(args, "-u")
+	}
+	args = append(args, remote, branch)
+
+	_, err := adapter.runGit(ctx, "push branch", args...)
+	return err
+}
+
+func (adapter *ShellAdapter) HasCommitsAhead(ctx context.Context, base string, head string) (bool, error) {
+	if strings.TrimSpace(base) == "" {
+		return false, fmt.Errorf("base ref must not be empty")
+	}
+	if strings.TrimSpace(head) == "" {
+		return false, fmt.Errorf("head ref must not be empty")
+	}
+
+	result, err := adapter.runGit(ctx, "rev-list count", "rev-list", "--count", base+".."+head)
+	if err != nil {
+		return false, err
+	}
+
+	return parseAheadCount(result.stdout)
+}
+
+func (adapter *ShellAdapter) runGit(ctx context.Context, operation string, args ...string) (commandResult, error) {
+	result, err := adapter.runner(ctx, adapter.gitPath, args...)
+	if err != nil {
+		return result, CommandError{
+			Operation: operation,
+			Stdout:    result.stdout,
+			Stderr:    result.stderr,
+			Err:       err,
+		}
+	}
+
+	return result, nil
+}
+
+func runCommand(ctx context.Context, name string, args ...string) (commandResult, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return commandResult{
+		stdout: strings.TrimSpace(stdout.String()),
+		stderr: strings.TrimSpace(stderr.String()),
+	}, err
+}
+
+func parseStatusOutput(output string) (bool, []string) {
+	if strings.TrimSpace(output) == "" {
+		return true, nil
+	}
+
+	trimmed := strings.TrimRight(output, "\r\n")
+	lines := strings.Split(trimmed, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], "\r")
+	}
+
+	return false, lines
+}
+
+func parseAheadCount(output string) (bool, error) {
+	count, err := strconv.Atoi(strings.TrimSpace(output))
+	if err != nil {
+		return false, fmt.Errorf("invalid git rev-list count %q: %w", output, err)
+	}
+
+	return count > 0, nil
+}
+
+func validateRemoteAndBranch(remote string, branch string) error {
+	if strings.TrimSpace(remote) == "" {
+		return fmt.Errorf("remote must not be empty")
+	}
+
+	return validateBranch(branch)
+}
+
+func validateBranch(branch string) error {
+	if strings.TrimSpace(branch) == "" {
+		return fmt.Errorf("branch name must not be empty")
+	}
+
+	return nil
+}
+
+func isProtectedBranch(branch string) bool {
+	_, ok := protectedBranches[strings.TrimSpace(branch)]
+	return ok
+}

--- a/tools/parsevkctl-go/internal/git/shell_test.go
+++ b/tools/parsevkctl-go/internal/git/shell_test.go
@@ -1,0 +1,254 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseStatusOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		clean bool
+		files []string
+	}{
+		{
+			name:  "clean status",
+			input: "\n",
+			clean: true,
+			files: nil,
+		},
+		{
+			name:  "dirty status",
+			input: " M README.md\n?? internal/git/git.go\n",
+			clean: false,
+			files: []string{" M README.md", "?? internal/git/git.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clean, files := parseStatusOutput(tt.input)
+
+			if clean != tt.clean {
+				t.Fatalf("clean = %v, want %v", clean, tt.clean)
+			}
+			if !reflect.DeepEqual(files, tt.files) {
+				t.Fatalf("files = %#v, want %#v", files, tt.files)
+			}
+		})
+	}
+}
+
+func TestDeleteLocalBranchRejectsProtectedBranches(t *testing.T) {
+	t.Parallel()
+
+	protected := []string{"main", "master", "fastapi-microservices-rewrite"}
+	for _, branch := range protected {
+		branch := branch
+		t.Run(branch, func(t *testing.T) {
+			t.Parallel()
+
+			adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
+				t.Fatalf("runner must not be called for protected branch %q", branch)
+				return commandResult{}, nil
+			})
+
+			err := adapter.DeleteLocalBranch(context.Background(), branch, false)
+			if err == nil {
+				t.Fatalf("expected protected branch error")
+			}
+			if !strings.Contains(err.Error(), "protected") {
+				t.Fatalf("error = %q, want protected branch message", err)
+			}
+		})
+	}
+}
+
+func TestEmptyBranchValidation(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
+		t.Fatal("runner must not be called when validation fails")
+		return commandResult{}, nil
+	})
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "switch", run: func() error { return adapter.Switch(context.Background(), " ") }},
+		{name: "create branch", run: func() error { return adapter.CreateBranch(context.Background(), "") }},
+		{name: "delete branch", run: func() error { return adapter.DeleteLocalBranch(context.Background(), "", false) }},
+		{name: "push branch", run: func() error { return adapter.PushBranch(context.Background(), "origin", "\t", false) }},
+		{name: "fetch remote", run: func() error { return adapter.Fetch(context.Background(), "", "feature") }},
+		{name: "fetch branch", run: func() error { return adapter.Fetch(context.Background(), "origin", "") }},
+		{name: "pull remote", run: func() error { return adapter.PullFFOnly(context.Background(), " ", "feature") }},
+		{name: "pull branch", run: func() error { return adapter.PullFFOnly(context.Background(), "origin", " ") }},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.run()
+			if err == nil {
+				t.Fatalf("expected validation error")
+			}
+		})
+	}
+}
+
+func TestParseAheadCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		ahead bool
+	}{
+		{name: "zero", input: "0\n", ahead: false},
+		{name: "positive", input: "12", ahead: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ahead, err := parseAheadCount(tt.input)
+			if err != nil {
+				t.Fatalf("parseAheadCount returned error: %v", err)
+			}
+			if ahead != tt.ahead {
+				t.Fatalf("ahead = %v, want %v", ahead, tt.ahead)
+			}
+		})
+	}
+}
+
+func TestParseAheadCountRejectsInvalidOutput(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseAheadCount("not-a-number")
+	if err == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+func TestCommandArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(*ShellAdapter) error
+		args []string
+	}{
+		{
+			name: "fetch",
+			run:  func(adapter *ShellAdapter) error { return adapter.Fetch(context.Background(), "origin", "main") },
+			args: []string{"fetch", "origin", "main"},
+		},
+		{
+			name: "switch",
+			run:  func(adapter *ShellAdapter) error { return adapter.Switch(context.Background(), "feature") },
+			args: []string{"switch", "feature"},
+		},
+		{
+			name: "pull ff only",
+			run:  func(adapter *ShellAdapter) error { return adapter.PullFFOnly(context.Background(), "origin", "main") },
+			args: []string{"pull", "--ff-only", "origin", "main"},
+		},
+		{
+			name: "create branch",
+			run:  func(adapter *ShellAdapter) error { return adapter.CreateBranch(context.Background(), "feature") },
+			args: []string{"switch", "-c", "feature"},
+		},
+		{
+			name: "delete branch",
+			run: func(adapter *ShellAdapter) error {
+				return adapter.DeleteLocalBranch(context.Background(), "feature", false)
+			},
+			args: []string{"branch", "-d", "feature"},
+		},
+		{
+			name: "force delete branch",
+			run: func(adapter *ShellAdapter) error {
+				return adapter.DeleteLocalBranch(context.Background(), "feature", true)
+			},
+			args: []string{"branch", "-D", "feature"},
+		},
+		{
+			name: "push branch",
+			run: func(adapter *ShellAdapter) error {
+				return adapter.PushBranch(context.Background(), "origin", "feature", false)
+			},
+			args: []string{"push", "origin", "feature"},
+		},
+		{
+			name: "push branch with upstream",
+			run: func(adapter *ShellAdapter) error {
+				return adapter.PushBranch(context.Background(), "origin", "feature", true)
+			},
+			args: []string{"push", "-u", "origin", "feature"},
+		},
+		{
+			name: "has commits ahead",
+			run: func(adapter *ShellAdapter) error {
+				_, err := adapter.HasCommitsAhead(context.Background(), "origin/main", "HEAD")
+				return err
+			},
+			args: []string{"rev-list", "--count", "origin/main..HEAD"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got []string
+			adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+				got = append([]string(nil), args...)
+				return commandResult{stdout: "1"}, nil
+			})
+
+			err := tt.run(adapter)
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.args) {
+				t.Fatalf("args = %#v, want %#v", got, tt.args)
+			}
+		})
+	}
+}
+
+func TestCommandErrorsIncludeOperationAndOutput(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
+		return commandResult{stdout: "stdout text", stderr: "stderr text"}, errors.New("exit status 1")
+	})
+
+	err := adapter.Fetch(context.Background(), "origin", "main")
+	if err == nil {
+		t.Fatalf("expected command error")
+	}
+
+	message := err.Error()
+	for _, want := range []string{"fetch", "stdout text", "stderr text"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("error = %q, want it to contain %q", message, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #107

## Summary
- Added internal/git Adapter interface for local Git operations.
- Implemented shell-backed Git adapter with centralized exec.CommandContext runner and structured command errors.
- Added unit tests for status parsing, validation, protected branch deletion, ahead-count parsing, command arguments, and command error output.

## Test plan
- go test ./...
- go build ./cmd/parsevkctl