### PR TITLE
Go rewrite: add GitHub adapter

### DIFF
--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -13,3 +13,7 @@ Run: go run ./cmd/parsevkctl --help
 ## Git adapter
 
 `internal/git` centralizes local Git operations for the Go rewrite. It exposes an adapter interface for repository actions and currently implements it with a shell-based adapter that calls `git` directly.
+
+## GitHub adapter
+
+`internal/github` centralizes GitHub operations for the Go rewrite. It exposes a typed adapter boundary for issues, pull requests and project status operations, and currently shells out to `gh` behind that boundary while returning `internal/domain` types.

--- a/tools/parsevkctl-go/internal/github/errors.go
+++ b/tools/parsevkctl-go/internal/github/errors.go
@@ -1,0 +1,60 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrProjectNotImplemented = errors.New("github project operations are not implemented")
+
+type CommandError struct {
+	Operation string
+	Args      []string
+	ExitCode  int
+	Stdout    string
+	Stderr    string
+	Err       error
+}
+
+func (err CommandError) Error() string {
+	parts := []string{fmt.Sprintf("gh %s failed", err.Operation)}
+	if len(err.Args) > 0 {
+		parts = append(parts, "args: "+strings.Join(err.Args, " "))
+	}
+	if err.ExitCode >= 0 {
+		parts = append(parts, fmt.Sprintf("exit code %d", err.ExitCode))
+	}
+	if err.Err != nil {
+		parts = append(parts, err.Err.Error())
+	}
+	if strings.TrimSpace(err.Stderr) != "" {
+		parts = append(parts, "stderr: "+err.Stderr)
+	}
+	if strings.TrimSpace(err.Stdout) != "" {
+		parts = append(parts, "stdout: "+err.Stdout)
+	}
+
+	return strings.Join(parts, ": ")
+}
+
+func (err CommandError) Unwrap() error {
+	return err.Err
+}
+
+type exitCoder interface {
+	ExitCode() int
+}
+
+func exitCodeOf(err error) int {
+	if err == nil {
+		return -1
+	}
+
+	var exitErr exitCoder
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+
+	return -1
+}

--- a/tools/parsevkctl-go/internal/github/github.go
+++ b/tools/parsevkctl-go/internal/github/github.go
@@ -1,0 +1,47 @@
+package github
+
+import (
+	"context"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+)
+
+type Adapter interface {
+	GetIssue(ctx context.Context, number int) (domain.Issue, error)
+	CreateIssue(ctx context.Context, input CreateIssueInput) (domain.Issue, error)
+	CloseIssue(ctx context.Context, number int, comment string) error
+
+	ListPullRequests(ctx context.Context, filter PullRequestFilter) ([]domain.PullRequest, error)
+	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (domain.PullRequest, error)
+	MergePullRequest(ctx context.Context, number int, input MergePullRequestInput) error
+
+	GetProjectItem(ctx context.Context, issueNumber int) (domain.ProjectItem, error)
+	SetProjectStatus(ctx context.Context, issueNumber int, status domain.ProjectStatus) error
+}
+
+type CreateIssueInput struct {
+	Title  string
+	Body   string
+	Labels []string
+}
+
+type PullRequestFilter struct {
+	State  string
+	Head   string
+	Base   string
+	Search string
+}
+
+type CreatePullRequestInput struct {
+	Title string
+	Body  string
+	Head  string
+	Base  string
+	Draft bool
+}
+
+type MergePullRequestInput struct {
+	Method       string
+	DeleteBranch bool
+	Auto         bool
+}

--- a/tools/parsevkctl-go/internal/github/parse.go
+++ b/tools/parsevkctl-go/internal/github/parse.go
@@ -1,0 +1,134 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+)
+
+type issueJSON struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	State       string `json:"state"`
+	HeadRefName string `json:"headRefName"`
+}
+
+type pullRequestJSON struct {
+	Number   int     `json:"number"`
+	Title    string  `json:"title"`
+	State    string  `json:"state"`
+	IsDraft  bool    `json:"isDraft"`
+	MergedAt *string `json:"mergedAt"`
+}
+
+func parseIssueJSON(data []byte) (domain.Issue, error) {
+	var raw issueJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return domain.Issue{}, fmt.Errorf("parse issue JSON: %w", err)
+	}
+
+	return issueFromJSON(raw), nil
+}
+
+func parsePullRequestJSON(data []byte) (domain.PullRequest, error) {
+	var raw pullRequestJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return domain.PullRequest{}, fmt.Errorf("parse pull request JSON: %w", err)
+	}
+
+	return pullRequestFromJSON(raw), nil
+}
+
+func parsePullRequestsJSON(data []byte) ([]domain.PullRequest, error) {
+	var raw []pullRequestJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse pull request list JSON: %w", err)
+	}
+
+	prs := make([]domain.PullRequest, 0, len(raw))
+	for _, item := range raw {
+		prs = append(prs, pullRequestFromJSON(item))
+	}
+
+	return prs, nil
+}
+
+func issueFromJSON(raw issueJSON) domain.Issue {
+	return domain.Issue{
+		ID:     domain.TaskID(raw.Number),
+		Title:  raw.Title,
+		State:  normalizeIssueState(raw.State),
+		Branch: domain.BranchName(raw.HeadRefName),
+	}
+}
+
+func pullRequestFromJSON(raw pullRequestJSON) domain.PullRequest {
+	merged := raw.MergedAt != nil || strings.EqualFold(raw.State, "MERGED")
+	state := normalizePullRequestState(raw.State, raw.IsDraft, merged)
+
+	return domain.PullRequest{
+		Number: domain.TaskID(raw.Number),
+		Title:  raw.Title,
+		State:  state,
+		Draft:  raw.IsDraft,
+		Merged: merged,
+	}
+}
+
+func normalizeIssueState(state string) domain.IssueState {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "OPEN":
+		return domain.IssueStateOpen
+	case "CLOSED":
+		return domain.IssueStateClosed
+	default:
+		return domain.IssueStateUnknown
+	}
+}
+
+func normalizePullRequestState(state string, draft bool, merged bool) domain.PullRequestState {
+	if merged {
+		return domain.PullRequestStateMerged
+	}
+	if draft {
+		return domain.PullRequestStateDraft
+	}
+
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "OPEN":
+		return domain.PullRequestStateOpen
+	case "CLOSED":
+		return domain.PullRequestStateClosed
+	case "MERGED":
+		return domain.PullRequestStateMerged
+	default:
+		return domain.PullRequestStateNone
+	}
+}
+
+func parseNumberFromURL(output string, kind string) (int, error) {
+	trimmed := strings.TrimSpace(output)
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s URL %q: %w", kind, trimmed, err)
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	for i := 0; i < len(parts)-1; i++ {
+		if parts[i] != kind {
+			continue
+		}
+
+		number, err := strconv.Atoi(parts[i+1])
+		if err != nil {
+			return 0, fmt.Errorf("parse %s number from URL %q: %w", kind, trimmed, err)
+		}
+		return number, nil
+	}
+
+	return 0, fmt.Errorf("could not find %s number in URL %q", kind, trimmed)
+}

--- a/tools/parsevkctl-go/internal/github/shell.go
+++ b/tools/parsevkctl-go/internal/github/shell.go
@@ -1,0 +1,238 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+)
+
+const (
+	issueJSONFields       = "number,title,state,headRefName"
+	pullRequestJSONFields = "number,title,state,isDraft,mergedAt"
+)
+
+type commandResult struct {
+	stdout string
+	stderr string
+}
+
+type commandRunner func(ctx context.Context, name string, args ...string) (commandResult, error)
+
+type ShellAdapter struct {
+	ghPath string
+	runner commandRunner
+}
+
+func NewShellAdapter() *ShellAdapter {
+	return newShellAdapterWithRunner(runCommand)
+}
+
+func newShellAdapterWithRunner(runner commandRunner) *ShellAdapter {
+	return &ShellAdapter{
+		ghPath: "gh",
+		runner: runner,
+	}
+}
+
+func (adapter *ShellAdapter) GetIssue(ctx context.Context, number int) (domain.Issue, error) {
+	if err := validateNumber("issue number", number); err != nil {
+		return domain.Issue{}, err
+	}
+
+	result, err := adapter.runGH(ctx, "get issue", "issue", "view", strconv.Itoa(number), "--json", issueJSONFields)
+	if err != nil {
+		return domain.Issue{}, err
+	}
+
+	return parseIssueJSON([]byte(result.stdout))
+}
+
+func (adapter *ShellAdapter) CreateIssue(ctx context.Context, input CreateIssueInput) (domain.Issue, error) {
+	if strings.TrimSpace(input.Title) == "" {
+		return domain.Issue{}, fmt.Errorf("issue title must not be empty")
+	}
+
+	args := []string{"issue", "create", "--title", input.Title}
+	if strings.TrimSpace(input.Body) != "" {
+		args = append(args, "--body", input.Body)
+	}
+	for _, label := range input.Labels {
+		if strings.TrimSpace(label) != "" {
+			args = append(args, "--label", label)
+		}
+	}
+
+	result, err := adapter.runGH(ctx, "create issue", args...)
+	if err != nil {
+		return domain.Issue{}, err
+	}
+
+	number, err := parseNumberFromURL(result.stdout, "issues")
+	if err != nil {
+		return domain.Issue{}, err
+	}
+
+	return adapter.GetIssue(ctx, number)
+}
+
+func (adapter *ShellAdapter) CloseIssue(ctx context.Context, number int, comment string) error {
+	if err := validateNumber("issue number", number); err != nil {
+		return err
+	}
+
+	args := []string{"issue", "close", strconv.Itoa(number)}
+	if strings.TrimSpace(comment) != "" {
+		args = append(args, "--comment", comment)
+	}
+
+	_, err := adapter.runGH(ctx, "close issue", args...)
+	return err
+}
+
+func (adapter *ShellAdapter) ListPullRequests(ctx context.Context, filter PullRequestFilter) ([]domain.PullRequest, error) {
+	args := []string{"pr", "list"}
+	if strings.TrimSpace(filter.State) != "" {
+		args = append(args, "--state", filter.State)
+	}
+	if strings.TrimSpace(filter.Head) != "" {
+		args = append(args, "--head", filter.Head)
+	}
+	if strings.TrimSpace(filter.Base) != "" {
+		args = append(args, "--base", filter.Base)
+	}
+	if strings.TrimSpace(filter.Search) != "" {
+		args = append(args, "--search", filter.Search)
+	}
+	args = append(args, "--json", pullRequestJSONFields)
+
+	result, err := adapter.runGH(ctx, "list pull requests", args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return parsePullRequestsJSON([]byte(result.stdout))
+}
+
+func (adapter *ShellAdapter) CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (domain.PullRequest, error) {
+	if strings.TrimSpace(input.Title) == "" {
+		return domain.PullRequest{}, fmt.Errorf("pull request title must not be empty")
+	}
+
+	args := []string{"pr", "create", "--title", input.Title}
+	if strings.TrimSpace(input.Body) != "" {
+		args = append(args, "--body", input.Body)
+	}
+	if strings.TrimSpace(input.Head) != "" {
+		args = append(args, "--head", input.Head)
+	}
+	if strings.TrimSpace(input.Base) != "" {
+		args = append(args, "--base", input.Base)
+	}
+	if input.Draft {
+		args = append(args, "--draft")
+	}
+
+	result, err := adapter.runGH(ctx, "create pull request", args...)
+	if err != nil {
+		return domain.PullRequest{}, err
+	}
+
+	number, err := parseNumberFromURL(result.stdout, "pull")
+	if err != nil {
+		return domain.PullRequest{}, err
+	}
+
+	return adapter.getPullRequest(ctx, number)
+}
+
+func (adapter *ShellAdapter) MergePullRequest(ctx context.Context, number int, input MergePullRequestInput) error {
+	if err := validateNumber("pull request number", number); err != nil {
+		return err
+	}
+
+	args := []string{"pr", "merge", strconv.Itoa(number)}
+	switch strings.ToLower(strings.TrimSpace(input.Method)) {
+	case "", "merge":
+		args = append(args, "--merge")
+	case "squash":
+		args = append(args, "--squash")
+	case "rebase":
+		args = append(args, "--rebase")
+	default:
+		return fmt.Errorf("unsupported pull request merge method %q", input.Method)
+	}
+	if input.DeleteBranch {
+		args = append(args, "--delete-branch")
+	}
+	if input.Auto {
+		args = append(args, "--auto")
+	}
+
+	_, err := adapter.runGH(ctx, "merge pull request", args...)
+	return err
+}
+
+func (adapter *ShellAdapter) GetProjectItem(context.Context, int) (domain.ProjectItem, error) {
+	return domain.ProjectItem{}, ErrProjectNotImplemented
+}
+
+func (adapter *ShellAdapter) SetProjectStatus(context.Context, int, domain.ProjectStatus) error {
+	return ErrProjectNotImplemented
+}
+
+func (adapter *ShellAdapter) getPullRequest(ctx context.Context, number int) (domain.PullRequest, error) {
+	if err := validateNumber("pull request number", number); err != nil {
+		return domain.PullRequest{}, err
+	}
+
+	result, err := adapter.runGH(ctx, "get pull request", "pr", "view", strconv.Itoa(number), "--json", pullRequestJSONFields)
+	if err != nil {
+		return domain.PullRequest{}, err
+	}
+
+	return parsePullRequestJSON([]byte(result.stdout))
+}
+
+func (adapter *ShellAdapter) runGH(ctx context.Context, operation string, args ...string) (commandResult, error) {
+	result, err := adapter.runner(ctx, adapter.ghPath, args...)
+	if err != nil {
+		return result, CommandError{
+			Operation: operation,
+			Args:      append([]string(nil), args...),
+			ExitCode:  exitCodeOf(err),
+			Stdout:    result.stdout,
+			Stderr:    result.stderr,
+			Err:       err,
+		}
+	}
+
+	return result, nil
+}
+
+func runCommand(ctx context.Context, name string, args ...string) (commandResult, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return commandResult{
+		stdout: strings.TrimSpace(stdout.String()),
+		stderr: strings.TrimSpace(stderr.String()),
+	}, err
+}
+
+func validateNumber(name string, number int) error {
+	if number <= 0 {
+		return fmt.Errorf("%s must be a positive integer", name)
+	}
+
+	return nil
+}

--- a/tools/parsevkctl-go/internal/github/shell_test.go
+++ b/tools/parsevkctl-go/internal/github/shell_test.go
@@ -1,0 +1,261 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+)
+
+func TestParseIssueJSON(t *testing.T) {
+	t.Parallel()
+
+	issue, err := parseIssueJSON([]byte(`{"number":108,"title":"Add adapter","state":"OPEN","headRefName":"feature"}`))
+	if err != nil {
+		t.Fatalf("parseIssueJSON returned error: %v", err)
+	}
+
+	want := domain.Issue{
+		ID:     domain.TaskID(108),
+		Title:  "Add adapter",
+		State:  domain.IssueStateOpen,
+		Branch: domain.BranchName("feature"),
+	}
+	if !reflect.DeepEqual(issue, want) {
+		t.Fatalf("issue = %#v, want %#v", issue, want)
+	}
+}
+
+func TestParsePullRequestsJSON(t *testing.T) {
+	t.Parallel()
+
+	prs, err := parsePullRequestsJSON([]byte(`[
+		{"number":7,"title":"Open PR","state":"OPEN","isDraft":true,"mergedAt":null},
+		{"number":8,"title":"Merged PR","state":"MERGED","isDraft":false,"mergedAt":"2026-05-22T00:00:00Z"}
+	]`))
+	if err != nil {
+		t.Fatalf("parsePullRequestsJSON returned error: %v", err)
+	}
+
+	want := []domain.PullRequest{
+		{
+			Number: domain.TaskID(7),
+			Title:  "Open PR",
+			State:  domain.PullRequestStateDraft,
+			Draft:  true,
+			Merged: false,
+		},
+		{
+			Number: domain.TaskID(8),
+			Title:  "Merged PR",
+			State:  domain.PullRequestStateMerged,
+			Draft:  false,
+			Merged: true,
+		},
+	}
+	if !reflect.DeepEqual(prs, want) {
+		t.Fatalf("prs = %#v, want %#v", prs, want)
+	}
+}
+
+func TestCommandArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(*ShellAdapter) error
+		args []string
+	}{
+		{
+			name: "get issue",
+			run: func(adapter *ShellAdapter) error {
+				_, err := adapter.GetIssue(context.Background(), 108)
+				return err
+			},
+			args: []string{"issue", "view", "108", "--json", "number,title,state,headRefName"},
+		},
+		{
+			name: "close issue with comment",
+			run: func(adapter *ShellAdapter) error {
+				return adapter.CloseIssue(context.Background(), 108, "Done")
+			},
+			args: []string{"issue", "close", "108", "--comment", "Done"},
+		},
+		{
+			name: "list pull requests",
+			run: func(adapter *ShellAdapter) error {
+				_, err := adapter.ListPullRequests(context.Background(), PullRequestFilter{
+					State:  "open",
+					Head:   "feature",
+					Base:   "main",
+					Search: "issue 108",
+				})
+				return err
+			},
+			args: []string{"pr", "list", "--state", "open", "--head", "feature", "--base", "main", "--search", "issue 108", "--json", "number,title,state,isDraft,mergedAt"},
+		},
+		{
+			name: "merge pull request",
+			run: func(adapter *ShellAdapter) error {
+				return adapter.MergePullRequest(context.Background(), 7, MergePullRequestInput{
+					Method:       "squash",
+					DeleteBranch: true,
+					Auto:         true,
+				})
+			},
+			args: []string{"pr", "merge", "7", "--squash", "--delete-branch", "--auto"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got []string
+			adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+				got = append([]string(nil), args...)
+				return commandResult{stdout: commandOutputFor(args)}, nil
+			})
+
+			if err := tt.run(adapter); err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.args) {
+				t.Fatalf("args = %#v, want %#v", got, tt.args)
+			}
+		})
+	}
+}
+
+func TestCreateIssueRunsCreateThenView(t *testing.T) {
+	t.Parallel()
+
+	var got [][]string
+	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+		got = append(got, append([]string(nil), args...))
+		if len(args) >= 2 && args[0] == "issue" && args[1] == "create" {
+			return commandResult{stdout: "https://github.com/andr-235/parseVK/issues/108"}, nil
+		}
+
+		return commandResult{stdout: `{"number":108,"title":"Issue","state":"OPEN","headRefName":"feature"}`}, nil
+	})
+
+	issue, err := adapter.CreateIssue(context.Background(), CreateIssueInput{
+		Title:  "Title",
+		Body:   "Body",
+		Labels: []string{"go", "cli"},
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue returned error: %v", err)
+	}
+	if issue.ID != domain.TaskID(108) {
+		t.Fatalf("issue ID = %d, want 108", issue.ID)
+	}
+
+	want := [][]string{
+		{"issue", "create", "--title", "Title", "--body", "Body", "--label", "go", "--label", "cli"},
+		{"issue", "view", "108", "--json", "number,title,state,headRefName"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestCreatePullRequestRunsCreateThenView(t *testing.T) {
+	t.Parallel()
+
+	var got [][]string
+	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+		got = append(got, append([]string(nil), args...))
+		if len(args) >= 2 && args[0] == "pr" && args[1] == "create" {
+			return commandResult{stdout: "https://github.com/andr-235/parseVK/pull/7"}, nil
+		}
+
+		return commandResult{stdout: `{"number":7,"title":"PR","state":"OPEN","isDraft":true,"mergedAt":null}`}, nil
+	})
+
+	pr, err := adapter.CreatePullRequest(context.Background(), CreatePullRequestInput{
+		Title: "Title",
+		Body:  "Body",
+		Head:  "feature",
+		Base:  "main",
+		Draft: true,
+	})
+	if err != nil {
+		t.Fatalf("CreatePullRequest returned error: %v", err)
+	}
+	if pr.Number != domain.TaskID(7) {
+		t.Fatalf("PR number = %d, want 7", pr.Number)
+	}
+
+	want := [][]string{
+		{"pr", "create", "--title", "Title", "--body", "Body", "--head", "feature", "--base", "main", "--draft"},
+		{"pr", "view", "7", "--json", "number,title,state,isDraft,mergedAt"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestCommandErrorsIncludeOperationArgsExitCodeAndOutput(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
+		return commandResult{stdout: "stdout text", stderr: "stderr text"}, fakeExitError{code: 2}
+	})
+
+	_, err := adapter.GetIssue(context.Background(), 108)
+	if err == nil {
+		t.Fatalf("expected command error")
+	}
+
+	message := err.Error()
+	for _, want := range []string{"get issue", "issue view 108", "exit code 2", "stdout text", "stderr text"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("error = %q, want it to contain %q", message, want)
+		}
+	}
+}
+
+func TestProjectMethodsReturnNotImplemented(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
+		t.Fatal("runner must not be called by project stubs")
+		return commandResult{}, nil
+	})
+
+	if _, err := adapter.GetProjectItem(context.Background(), 108); !errors.Is(err, ErrProjectNotImplemented) {
+		t.Fatalf("GetProjectItem error = %v, want ErrProjectNotImplemented", err)
+	}
+	if err := adapter.SetProjectStatus(context.Background(), 108, domain.ProjectStatusReview); !errors.Is(err, ErrProjectNotImplemented) {
+		t.Fatalf("SetProjectStatus error = %v, want ErrProjectNotImplemented", err)
+	}
+}
+
+type fakeExitError struct {
+	code int
+}
+
+func (err fakeExitError) Error() string {
+	return "exit status"
+}
+
+func (err fakeExitError) ExitCode() int {
+	return err.code
+}
+
+func commandOutputFor(args []string) string {
+	if len(args) >= 2 && args[0] == "pr" && (args[1] == "list" || args[1] == "create") {
+		if args[1] == "list" {
+			return `[{"number":7,"title":"PR","state":"OPEN","isDraft":false,"mergedAt":null}]`
+		}
+		return `{"number":7,"title":"PR","state":"OPEN","isDraft":false,"mergedAt":null}`
+	}
+
+	return `{"number":108,"title":"Issue","state":"OPEN","headRefName":"feature"}`
+}


### PR DESCRIPTION
Closes #108

## Summary
- Added `tools/parsevkctl-go/internal/github` with a typed `Adapter` boundary for GitHub IO.
- Implemented a shell-backed `gh` adapter with centralized command execution, typed JSON parsing and normalized command errors.
- Added project operation stubs returning a clear not implemented error.
- Documented the GitHub adapter in `tools/parsevkctl-go/README.md`.

## Test plan
- `cd tools/parsevkctl-go; go test ./...`
- `cd tools/parsevkctl-go; go build ./cmd/parsevkctl`