### PR TITLE
Go rewrite: add task lifecycle state machine

### DIFF
--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -10,6 +10,10 @@ Run: go run ./cmd/parsevkctl --help
 
 `internal/domain` contains pure Go types for tasks, issues, pull requests, project items and lifecycle state. It also owns validation helpers and task state derivation logic, without dependencies on the CLI, Git, GitHub, Project adapters or output rendering.
 
+## Task lifecycle
+
+`internal/task` contains pure lifecycle state derivation and transition validation for task automation. Command handlers will use this package later to map issue, project, pull request and branch snapshots into valid task lifecycle actions.
+
 ## Git adapter
 
 `internal/git` centralizes local Git operations for the Go rewrite. It exposes an adapter interface for repository actions and currently implements it with a shell-based adapter that calls `git` directly.

--- a/tools/parsevkctl-go/internal/task/lifecycle.go
+++ b/tools/parsevkctl-go/internal/task/lifecycle.go
@@ -1,0 +1,149 @@
+package task
+
+import (
+	"fmt"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+)
+
+type LifecycleSnapshot struct {
+	IssueExists        bool
+	IssueState         domain.IssueState
+	ProjectStatus      domain.ProjectStatus
+	PullRequestState   domain.PullRequestState
+	PullRequestDraft   bool
+	PullRequestMerged  bool
+	LocalBranchExists  bool
+	RemoteBranchExists bool
+}
+
+type TransitionOptions struct {
+	Force   bool
+	NonCode bool
+}
+
+func DeriveState(snapshot LifecycleSnapshot) domain.TaskState {
+	if !snapshot.IssueExists {
+		return domain.TaskStateUntracked
+	}
+
+	if snapshot.IssueState == domain.IssueStateClosed {
+		return domain.TaskStateDone
+	}
+
+	if snapshot.PullRequestMerged || snapshot.PullRequestState == domain.PullRequestStateMerged {
+		return domain.TaskStateMerged
+	}
+
+	if snapshot.PullRequestDraft {
+		return domain.TaskStateReview
+	}
+
+	if snapshot.PullRequestState == domain.PullRequestStateOpen {
+		return domain.TaskStateReview
+	}
+
+	switch snapshot.ProjectStatus {
+	case domain.ProjectStatusReview:
+		return domain.TaskStateReview
+	case domain.ProjectStatusInProgress:
+		return domain.TaskStateInProgress
+	case domain.ProjectStatusTodo:
+		return domain.TaskStateTodo
+	case domain.ProjectStatusDone:
+		return domain.TaskStateDone
+	}
+
+	if snapshot.LocalBranchExists || snapshot.RemoteBranchExists {
+		return domain.TaskStateInProgress
+	}
+
+	return domain.TaskStateInvalid
+}
+
+func ValidateTransition(current domain.TaskState, target domain.TaskState, opts TransitionOptions) error {
+	if transitionAllowed(current, target, opts) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"invalid task transition from %q to %q; suggested next command: %s",
+		current,
+		target,
+		SuggestedNextCommand(current),
+	)
+}
+
+func SuggestedNextCommand(state domain.TaskState) string {
+	switch state {
+	case domain.TaskStateUntracked:
+		return "parsevkctl task create ..."
+	case domain.TaskStateTodo:
+		return "parsevkctl task start <issue>"
+	case domain.TaskStateInProgress:
+		return "parsevkctl task pr <issue>"
+	case domain.TaskStateReview:
+		return "parsevkctl task merge <issue>"
+	case domain.TaskStateMerged:
+		return "parsevkctl task sync <issue> --apply"
+	case domain.TaskStateDone:
+		return "no action required"
+	case domain.TaskStateInvalid:
+		return "parsevkctl task status <issue>"
+	default:
+		return "parsevkctl task status <issue>"
+	}
+}
+
+func transitionAllowed(current domain.TaskState, target domain.TaskState, opts TransitionOptions) bool {
+	if target == domain.TaskStateInvalid {
+		return false
+	}
+
+	if current == target {
+		return true
+	}
+
+	if current == domain.TaskStateInvalid {
+		return opts.Force
+	}
+
+	if current == domain.TaskStateDone && target != domain.TaskStateDone {
+		return opts.Force
+	}
+
+	if isNormalTransition(current, target) {
+		return true
+	}
+
+	if isNonCodeDoneTransition(current, target) {
+		return opts.NonCode || opts.Force
+	}
+
+	return opts.Force
+}
+
+func isNormalTransition(current domain.TaskState, target domain.TaskState) bool {
+	switch current {
+	case domain.TaskStateUntracked:
+		return target == domain.TaskStateTodo
+	case domain.TaskStateTodo:
+		return target == domain.TaskStateInProgress
+	case domain.TaskStateInProgress:
+		return target == domain.TaskStateReview
+	case domain.TaskStateReview:
+		return target == domain.TaskStateMerged
+	case domain.TaskStateMerged:
+		return target == domain.TaskStateDone
+	default:
+		return false
+	}
+}
+
+func isNonCodeDoneTransition(current domain.TaskState, target domain.TaskState) bool {
+	if target != domain.TaskStateDone {
+		return false
+	}
+
+	return current == domain.TaskStateTodo || current == domain.TaskStateInProgress
+}

--- a/tools/parsevkctl-go/internal/task/lifecycle_test.go
+++ b/tools/parsevkctl-go/internal/task/lifecycle_test.go
@@ -1,0 +1,258 @@
+package task
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+)
+
+func TestDeriveState(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot LifecycleSnapshot
+		expected domain.TaskState
+	}{
+		{
+			name:     "returns Untracked when issue is missing",
+			snapshot: LifecycleSnapshot{},
+			expected: domain.TaskStateUntracked,
+		},
+		{
+			name: "returns Done for closed issue",
+			snapshot: LifecycleSnapshot{
+				IssueExists: true,
+				IssueState:  domain.IssueStateClosed,
+			},
+			expected: domain.TaskStateDone,
+		},
+		{
+			name: "returns Merged for merged PR flag",
+			snapshot: LifecycleSnapshot{
+				IssueExists:       true,
+				IssueState:        domain.IssueStateOpen,
+				PullRequestMerged: true,
+			},
+			expected: domain.TaskStateMerged,
+		},
+		{
+			name: "returns Merged for merged PR state",
+			snapshot: LifecycleSnapshot{
+				IssueExists:      true,
+				IssueState:       domain.IssueStateOpen,
+				PullRequestState: domain.PullRequestStateMerged,
+			},
+			expected: domain.TaskStateMerged,
+		},
+		{
+			name: "returns Review for draft PR",
+			snapshot: LifecycleSnapshot{
+				IssueExists:      true,
+				IssueState:       domain.IssueStateOpen,
+				PullRequestDraft: true,
+			},
+			expected: domain.TaskStateReview,
+		},
+		{
+			name: "returns Review for open PR",
+			snapshot: LifecycleSnapshot{
+				IssueExists:      true,
+				IssueState:       domain.IssueStateOpen,
+				PullRequestState: domain.PullRequestStateOpen,
+			},
+			expected: domain.TaskStateReview,
+		},
+		{
+			name: "returns Review for project Review",
+			snapshot: LifecycleSnapshot{
+				IssueExists:   true,
+				IssueState:    domain.IssueStateOpen,
+				ProjectStatus: domain.ProjectStatusReview,
+			},
+			expected: domain.TaskStateReview,
+		},
+		{
+			name: "returns InProgress for project In Progress",
+			snapshot: LifecycleSnapshot{
+				IssueExists:   true,
+				IssueState:    domain.IssueStateOpen,
+				ProjectStatus: domain.ProjectStatusInProgress,
+			},
+			expected: domain.TaskStateInProgress,
+		},
+		{
+			name: "returns Todo for project Todo",
+			snapshot: LifecycleSnapshot{
+				IssueExists:   true,
+				IssueState:    domain.IssueStateOpen,
+				ProjectStatus: domain.ProjectStatusTodo,
+			},
+			expected: domain.TaskStateTodo,
+		},
+		{
+			name: "returns Done for project Done",
+			snapshot: LifecycleSnapshot{
+				IssueExists:   true,
+				IssueState:    domain.IssueStateOpen,
+				ProjectStatus: domain.ProjectStatusDone,
+			},
+			expected: domain.TaskStateDone,
+		},
+		{
+			name: "returns InProgress when local branch exists and issue exists",
+			snapshot: LifecycleSnapshot{
+				IssueExists:       true,
+				IssueState:        domain.IssueStateOpen,
+				LocalBranchExists: true,
+			},
+			expected: domain.TaskStateInProgress,
+		},
+		{
+			name: "returns InProgress when remote branch exists and issue exists",
+			snapshot: LifecycleSnapshot{
+				IssueExists:        true,
+				IssueState:         domain.IssueStateOpen,
+				RemoteBranchExists: true,
+			},
+			expected: domain.TaskStateInProgress,
+		},
+		{
+			name: "returns Invalid for unknown snapshot",
+			snapshot: LifecycleSnapshot{
+				IssueExists: true,
+				IssueState:  domain.IssueStateOpen,
+			},
+			expected: domain.TaskStateInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DeriveState(tt.snapshot)
+			if got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestValidateTransitionAllowsNormalFlow(t *testing.T) {
+	tests := []struct {
+		name    string
+		current domain.TaskState
+		target  domain.TaskState
+	}{
+		{name: "Untracked to Todo", current: domain.TaskStateUntracked, target: domain.TaskStateTodo},
+		{name: "Todo to InProgress", current: domain.TaskStateTodo, target: domain.TaskStateInProgress},
+		{name: "InProgress to Review", current: domain.TaskStateInProgress, target: domain.TaskStateReview},
+		{name: "Review to Merged", current: domain.TaskStateReview, target: domain.TaskStateMerged},
+		{name: "Merged to Done", current: domain.TaskStateMerged, target: domain.TaskStateDone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateTransition(tt.current, tt.target, TransitionOptions{}); err != nil {
+				t.Fatalf("expected transition to be allowed, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateTransitionDeniesInvalidFlow(t *testing.T) {
+	tests := []struct {
+		name    string
+		current domain.TaskState
+		target  domain.TaskState
+		opts    TransitionOptions
+	}{
+		{name: "Todo to Review", current: domain.TaskStateTodo, target: domain.TaskStateReview},
+		{name: "Todo to Done without NonCode or Force", current: domain.TaskStateTodo, target: domain.TaskStateDone},
+		{name: "InProgress to Done without NonCode or Force", current: domain.TaskStateInProgress, target: domain.TaskStateDone},
+		{name: "Done to InProgress without Force", current: domain.TaskStateDone, target: domain.TaskStateInProgress},
+		{name: "Invalid to Todo without Force", current: domain.TaskStateInvalid, target: domain.TaskStateTodo},
+		{name: "Any to Invalid", current: domain.TaskStateTodo, target: domain.TaskStateInvalid},
+		{name: "Any to Invalid with Force", current: domain.TaskStateTodo, target: domain.TaskStateInvalid, opts: TransitionOptions{Force: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTransition(tt.current, tt.target, tt.opts)
+			if err == nil {
+				t.Fatal("expected transition to be rejected")
+			}
+
+			message := err.Error()
+			for _, want := range []string{string(tt.current), string(tt.target), SuggestedNextCommand(tt.current)} {
+				if !strings.Contains(message, want) {
+					t.Fatalf("expected error %q to include %q", message, want)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateTransitionAllowsSpecialFlow(t *testing.T) {
+	tests := []struct {
+		name    string
+		current domain.TaskState
+		target  domain.TaskState
+		opts    TransitionOptions
+	}{
+		{
+			name:    "Todo to Done with NonCode",
+			current: domain.TaskStateTodo,
+			target:  domain.TaskStateDone,
+			opts:    TransitionOptions{NonCode: true},
+		},
+		{
+			name:    "InProgress to Done with NonCode",
+			current: domain.TaskStateInProgress,
+			target:  domain.TaskStateDone,
+			opts:    TransitionOptions{NonCode: true},
+		},
+		{
+			name:    "Invalid to Todo with Force",
+			current: domain.TaskStateInvalid,
+			target:  domain.TaskStateTodo,
+			opts:    TransitionOptions{Force: true},
+		},
+		{
+			name:    "Done to InProgress with Force",
+			current: domain.TaskStateDone,
+			target:  domain.TaskStateInProgress,
+			opts:    TransitionOptions{Force: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateTransition(tt.current, tt.target, tt.opts); err != nil {
+				t.Fatalf("expected transition to be allowed, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSuggestedNextCommand(t *testing.T) {
+	tests := []struct {
+		state    domain.TaskState
+		expected string
+	}{
+		{state: domain.TaskStateUntracked, expected: "parsevkctl task create ..."},
+		{state: domain.TaskStateTodo, expected: "parsevkctl task start <issue>"},
+		{state: domain.TaskStateInProgress, expected: "parsevkctl task pr <issue>"},
+		{state: domain.TaskStateReview, expected: "parsevkctl task merge <issue>"},
+		{state: domain.TaskStateMerged, expected: "parsevkctl task sync <issue> --apply"},
+		{state: domain.TaskStateDone, expected: "no action required"},
+		{state: domain.TaskStateInvalid, expected: "parsevkctl task status <issue>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			got := SuggestedNextCommand(tt.state)
+			if got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #110

## Summary
- Added pure Go task lifecycle state derivation in internal/task.
- Added transition validation with force/non-code overrides and suggested next commands.
- Documented the lifecycle package for future command handler integration.

## Test plan
- go test ./...
- go build ./cmd/parsevkctl

## Risk
- Low: pure package only, no CLI, Git, GitHub or PowerShell implementation changes.