### PR TITLE
Go rewrite: add planner executor

### DIFF
--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -14,6 +14,14 @@ Run: go run ./cmd/parsevkctl --help
 
 `internal/task` contains pure lifecycle state derivation and transition validation for task automation. Command handlers will use this package later to map issue, project, pull request and branch snapshots into valid task lifecycle actions.
 
+## Planner and executor
+
+`internal/planner` builds side-effect-free operation plans for task lifecycle commands. A plan describes the intended Git, GitHub and project operations in stable order and can be serialized to JSON.
+
+The planner does not call Git or GitHub directly. `Executor` applies a plan serially through the typed `internal/git` and `internal/github` adapters, stopping at the first failed operation with an operation-scoped error and recovery hint.
+
+`RenderDryRun` renders the same plan as deterministic human-readable lines without executing anything.
+
 ## Git adapter
 
 `internal/git` centralizes local Git operations for the Go rewrite. It exposes an adapter interface for repository actions and currently implements it with a shell-based adapter that calls `git` directly.

--- a/tools/parsevkctl-go/internal/git/git.go
+++ b/tools/parsevkctl-go/internal/git/git.go
@@ -10,6 +10,7 @@ type Adapter interface {
 	PullFFOnly(ctx context.Context, remote string, branch string) error
 	CreateBranch(ctx context.Context, branch string) error
 	DeleteLocalBranch(ctx context.Context, branch string, force bool) error
+	DeleteRemoteBranch(ctx context.Context, remote string, branch string) error
 	PushBranch(ctx context.Context, remote string, branch string, setUpstream bool) error
 	HasCommitsAhead(ctx context.Context, base string, head string) (bool, error)
 }

--- a/tools/parsevkctl-go/internal/git/shell.go
+++ b/tools/parsevkctl-go/internal/git/shell.go
@@ -110,6 +110,18 @@ func (adapter *ShellAdapter) DeleteLocalBranch(ctx context.Context, branch strin
 	return err
 }
 
+func (adapter *ShellAdapter) DeleteRemoteBranch(ctx context.Context, remote string, branch string) error {
+	if err := validateRemoteAndBranch(remote, branch); err != nil {
+		return err
+	}
+	if isProtectedBranch(branch) {
+		return fmt.Errorf("refusing to delete protected branch %q", strings.TrimSpace(branch))
+	}
+
+	_, err := adapter.runGit(ctx, "delete remote branch", "push", remote, "--delete", branch)
+	return err
+}
+
 func (adapter *ShellAdapter) PushBranch(ctx context.Context, remote string, branch string, setUpstream bool) error {
 	if err := validateRemoteAndBranch(remote, branch); err != nil {
 		return err

--- a/tools/parsevkctl-go/internal/github/github.go
+++ b/tools/parsevkctl-go/internal/github/github.go
@@ -16,6 +16,7 @@ type Adapter interface {
 	MergePullRequest(ctx context.Context, number int, input MergePullRequestInput) error
 
 	GetProjectItem(ctx context.Context, issueNumber int) (domain.ProjectItem, error)
+	AddProjectItem(ctx context.Context, issueNumber int) error
 	SetProjectStatus(ctx context.Context, issueNumber int, status domain.ProjectStatus) error
 }
 

--- a/tools/parsevkctl-go/internal/github/shell.go
+++ b/tools/parsevkctl-go/internal/github/shell.go
@@ -181,6 +181,10 @@ func (adapter *ShellAdapter) GetProjectItem(context.Context, int) (domain.Projec
 	return domain.ProjectItem{}, ErrProjectNotImplemented
 }
 
+func (adapter *ShellAdapter) AddProjectItem(context.Context, int) error {
+	return ErrProjectNotImplemented
+}
+
 func (adapter *ShellAdapter) SetProjectStatus(context.Context, int, domain.ProjectStatus) error {
 	return ErrProjectNotImplemented
 }

--- a/tools/parsevkctl-go/internal/planner/executor.go
+++ b/tools/parsevkctl-go/internal/planner/executor.go
@@ -1,0 +1,187 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/git"
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/github"
+)
+
+type Executor struct {
+	Git    git.Adapter
+	GitHub github.Adapter
+}
+
+type OperationError struct {
+	OperationID   string
+	OperationType OperationType
+	Message       string
+	RecoveryHint  string
+	Cause         error
+}
+
+func (e OperationError) Error() string {
+	if e.Cause == nil {
+		return fmt.Sprintf("%s (%s): %s", e.OperationID, e.OperationType, e.Message)
+	}
+
+	return fmt.Sprintf("%s (%s): %s: %v", e.OperationID, e.OperationType, e.Message, e.Cause)
+}
+
+func (e OperationError) Unwrap() error {
+	return e.Cause
+}
+
+func (e Executor) Execute(ctx context.Context, plan Plan) error {
+	for _, operation := range plan.Operations {
+		if err := e.executeOperation(ctx, operation); err != nil {
+			return OperationError{
+				OperationID:   operation.ID,
+				OperationType: operation.Type,
+				Message:       "operation failed",
+				RecoveryHint:  recoveryHint(operation),
+				Cause:         err,
+			}
+		}
+	}
+
+	return nil
+}
+
+func (e Executor) executeOperation(ctx context.Context, operation Operation) error {
+	switch operation.Type {
+	case OperationIssueCreate:
+		payload, err := payloadAs[IssueCreatePayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		_, err = e.GitHub.CreateIssue(ctx, github.CreateIssueInput{
+			Title:  payload.Title,
+			Body:   payload.Body,
+			Labels: payload.Labels,
+		})
+		return err
+	case OperationIssueClose:
+		payload, err := payloadAs[IssueClosePayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.GitHub.CloseIssue(ctx, payload.IssueNumber, payload.Comment)
+	case OperationProjectAddItem:
+		payload, err := payloadAs[ProjectIssuePayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.GitHub.AddProjectItem(ctx, payload.IssueNumber)
+	case OperationProjectSetStatus:
+		payload, err := payloadAs[ProjectStatusPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.GitHub.SetProjectStatus(ctx, payload.IssueNumber, payload.Status)
+	case OperationGitFetch:
+		payload, err := payloadAs[GitRefPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.Git.Fetch(ctx, payload.Remote, payload.Branch)
+	case OperationGitSwitch:
+		payload, err := payloadAs[GitBranchPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.Git.Switch(ctx, payload.Branch)
+	case OperationGitPullFastForward:
+		payload, err := payloadAs[GitRefPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.Git.PullFFOnly(ctx, payload.Remote, payload.Branch)
+	case OperationGitCreateBranch:
+		payload, err := payloadAs[GitBranchPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.Git.CreateBranch(ctx, payload.Branch)
+	case OperationGitPushBranch:
+		payload, err := payloadAs[GitRefPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.Git.PushBranch(ctx, payload.Remote, payload.Branch, true)
+	case OperationPullRequestCreate:
+		payload, err := payloadAs[PullRequestPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		_, err = e.GitHub.CreatePullRequest(ctx, github.CreatePullRequestInput{
+			Title: payload.Title,
+			Body:  payload.Body,
+			Head:  payload.Head,
+			Base:  payload.Base,
+			Draft: payload.Draft,
+		})
+		return err
+	case OperationPullRequestMerge:
+		payload, err := payloadAs[MergePullRequestPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.GitHub.MergePullRequest(ctx, payload.Number, github.MergePullRequestInput{
+			Method:       payload.Method,
+			DeleteBranch: payload.DeleteBranch,
+			Auto:         payload.Auto,
+		})
+	case OperationBranchDeleteLocal:
+		payload, err := payloadAs[DeleteLocalBranchPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.Git.DeleteLocalBranch(ctx, payload.Branch, payload.Force)
+	case OperationBranchDeleteRemote:
+		payload, err := payloadAs[GitRefPayload](operation.Payload)
+		if err != nil {
+			return err
+		}
+		return e.Git.DeleteRemoteBranch(ctx, payload.Remote, payload.Branch)
+	default:
+		return fmt.Errorf("unsupported operation type %q", operation.Type)
+	}
+}
+
+type IssueCreatePayload struct {
+	Title  string   `json:"title"`
+	Body   string   `json:"body"`
+	Labels []string `json:"labels,omitempty"`
+}
+
+type IssueClosePayload struct {
+	IssueNumber int    `json:"issueNumber"`
+	Comment     string `json:"comment,omitempty"`
+}
+
+func payloadAs[T any](payload any) (T, error) {
+	typed, ok := payload.(T)
+	if !ok {
+		var zero T
+		return zero, fmt.Errorf("invalid payload type %T", payload)
+	}
+
+	return typed, nil
+}
+
+func recoveryHint(operation Operation) string {
+	switch operation.Type {
+	case OperationProjectAddItem, OperationProjectSetStatus:
+		return "Check GitHub Project access and rerun the task operation when project state is available."
+	case OperationGitFetch, OperationGitSwitch, OperationGitPullFastForward, OperationGitCreateBranch, OperationGitPushBranch, OperationBranchDeleteLocal, OperationBranchDeleteRemote:
+		return "Check the local git state, resolve the reported git error, then rerun the task operation."
+	case OperationPullRequestCreate, OperationPullRequestMerge:
+		return "Check pull request state and GitHub permissions, then rerun the task operation."
+	case OperationIssueCreate, OperationIssueClose:
+		return "Check issue state and GitHub permissions, then rerun the task operation."
+	default:
+		return "Resolve the adapter error and rerun the task operation."
+	}
+}

--- a/tools/parsevkctl-go/internal/planner/executor_test.go
+++ b/tools/parsevkctl-go/internal/planner/executor_test.go
@@ -1,0 +1,200 @@
+package planner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/github"
+)
+
+func TestExecutorStopsOnFirstFailedOperation(t *testing.T) {
+	fakeGit := &fakeGitAdapter{failOn: "PullFFOnly", failErr: errors.New("pull failed")}
+	fakeGitHub := &fakeGitHubAdapter{}
+	executor := Executor{Git: fakeGit, GitHub: fakeGitHub}
+
+	plan, err := NewStartTaskPlan(StartTaskInput{
+		Issue:         domain.Issue{ID: 111},
+		DefaultBranch: "fastapi-microservices-rewrite",
+		BranchName:    "feat/issue-111-planner",
+		TargetStatus:  domain.ProjectStatusInProgress,
+	})
+	if err != nil {
+		t.Fatalf("NewStartTaskPlan returned error: %v", err)
+	}
+
+	err = executor.Execute(context.Background(), plan)
+	if err == nil {
+		t.Fatal("Execute returned nil error")
+	}
+
+	var operationErr OperationError
+	if !errors.As(err, &operationErr) {
+		t.Fatalf("Execute error type = %T, want OperationError", err)
+	}
+	if operationErr.OperationID != "git-pull-fast-forward-default-branch" {
+		t.Fatalf("OperationID = %q, want git-pull-fast-forward-default-branch", operationErr.OperationID)
+	}
+	if operationErr.OperationType != OperationGitPullFastForward {
+		t.Fatalf("OperationType = %q, want %q", operationErr.OperationType, OperationGitPullFastForward)
+	}
+	if !errors.Is(operationErr.Cause, fakeGit.failErr) {
+		t.Fatalf("Cause = %v, want %v", operationErr.Cause, fakeGit.failErr)
+	}
+
+	wantGitCalls := []string{
+		"Fetch:origin:fastapi-microservices-rewrite",
+		"Switch:fastapi-microservices-rewrite",
+		"PullFFOnly:origin:fastapi-microservices-rewrite",
+	}
+	if !reflect.DeepEqual(fakeGit.calls, wantGitCalls) {
+		t.Fatalf("git calls = %#v, want %#v", fakeGit.calls, wantGitCalls)
+	}
+	if len(fakeGitHub.calls) != 1 || fakeGitHub.calls[0] != "SetProjectStatus:111:In Progress" {
+		t.Fatalf("github calls = %#v, want SetProjectStatus only", fakeGitHub.calls)
+	}
+}
+
+func TestExecutorCallsAdaptersInExpectedOrder(t *testing.T) {
+	recorder := &callRecorder{}
+	fakeGit := &fakeGitAdapter{recorder: recorder}
+	fakeGitHub := &fakeGitHubAdapter{recorder: recorder}
+	executor := Executor{Git: fakeGit, GitHub: fakeGitHub}
+
+	plan, err := NewCreatePullRequestPlan(CreatePullRequestInput{
+		Issue:        domain.Issue{ID: 111},
+		BranchName:   "feat/issue-111-planner",
+		BaseBranch:   "fastapi-microservices-rewrite",
+		Title:        "Go rewrite: add planner executor",
+		Body:         "Closes #111",
+		TargetStatus: domain.ProjectStatusReview,
+	})
+	if err != nil {
+		t.Fatalf("NewCreatePullRequestPlan returned error: %v", err)
+	}
+
+	if err := executor.Execute(context.Background(), plan); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	want := []string{
+		"git.PushBranch:origin:feat/issue-111-planner:true",
+		"github.CreatePullRequest:Go rewrite: add planner executor:feat/issue-111-planner:fastapi-microservices-rewrite",
+		"github.SetProjectStatus:111:Review",
+	}
+	if !reflect.DeepEqual(recorder.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", recorder.calls, want)
+	}
+}
+
+type callRecorder struct {
+	calls []string
+}
+
+func (r *callRecorder) add(call string) {
+	if r != nil {
+		r.calls = append(r.calls, call)
+	}
+}
+
+type fakeGitAdapter struct {
+	calls    []string
+	failOn   string
+	failErr  error
+	recorder *callRecorder
+}
+
+func (f *fakeGitAdapter) CurrentBranch(context.Context) (string, error) { return "", nil }
+
+func (f *fakeGitAdapter) IsWorkTreeClean(context.Context) (bool, []string, error) {
+	return true, nil, nil
+}
+
+func (f *fakeGitAdapter) Fetch(_ context.Context, remote string, branch string) error {
+	return f.record("Fetch", remote+":"+branch)
+}
+
+func (f *fakeGitAdapter) Switch(_ context.Context, branch string) error {
+	return f.record("Switch", branch)
+}
+
+func (f *fakeGitAdapter) PullFFOnly(_ context.Context, remote string, branch string) error {
+	return f.record("PullFFOnly", remote+":"+branch)
+}
+
+func (f *fakeGitAdapter) CreateBranch(_ context.Context, branch string) error {
+	return f.record("CreateBranch", branch)
+}
+
+func (f *fakeGitAdapter) DeleteLocalBranch(_ context.Context, branch string, force bool) error {
+	return f.record("DeleteLocalBranch", branch)
+}
+
+func (f *fakeGitAdapter) DeleteRemoteBranch(_ context.Context, remote string, branch string) error {
+	return f.record("DeleteRemoteBranch", remote+":"+branch)
+}
+
+func (f *fakeGitAdapter) PushBranch(_ context.Context, remote string, branch string, setUpstream bool) error {
+	f.recorder.add("git.PushBranch:" + remote + ":" + branch + ":" + strconv.FormatBool(setUpstream))
+	return f.record("PushBranch", remote+":"+branch)
+}
+
+func (f *fakeGitAdapter) HasCommitsAhead(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+
+func (f *fakeGitAdapter) record(method string, detail string) error {
+	f.calls = append(f.calls, method+":"+detail)
+	if f.failOn == method {
+		return f.failErr
+	}
+	return nil
+}
+
+type fakeGitHubAdapter struct {
+	calls    []string
+	recorder *callRecorder
+}
+
+func (f *fakeGitHubAdapter) GetIssue(context.Context, int) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+
+func (f *fakeGitHubAdapter) CreateIssue(context.Context, github.CreateIssueInput) (domain.Issue, error) {
+	return domain.Issue{}, nil
+}
+
+func (f *fakeGitHubAdapter) CloseIssue(context.Context, int, string) error { return nil }
+
+func (f *fakeGitHubAdapter) ListPullRequests(context.Context, github.PullRequestFilter) ([]domain.PullRequest, error) {
+	return nil, nil
+}
+
+func (f *fakeGitHubAdapter) CreatePullRequest(_ context.Context, input github.CreatePullRequestInput) (domain.PullRequest, error) {
+	f.calls = append(f.calls, "CreatePullRequest:"+input.Head+":"+input.Base)
+	f.recorder.add("github.CreatePullRequest:" + input.Title + ":" + input.Head + ":" + input.Base)
+	return domain.PullRequest{Number: 10, Title: input.Title, State: domain.PullRequestStateOpen}, nil
+}
+
+func (f *fakeGitHubAdapter) MergePullRequest(context.Context, int, github.MergePullRequestInput) error {
+	return nil
+}
+
+func (f *fakeGitHubAdapter) GetProjectItem(context.Context, int) (domain.ProjectItem, error) {
+	return domain.ProjectItem{}, nil
+}
+
+func (f *fakeGitHubAdapter) AddProjectItem(_ context.Context, issueNumber int) error {
+	f.calls = append(f.calls, "AddProjectItem:"+strconv.Itoa(issueNumber))
+	return nil
+}
+
+func (f *fakeGitHubAdapter) SetProjectStatus(_ context.Context, issueNumber int, status domain.ProjectStatus) error {
+	call := "SetProjectStatus:" + strconv.Itoa(issueNumber) + ":" + string(status)
+	f.calls = append(f.calls, call)
+	f.recorder.add("github." + call)
+	return nil
+}

--- a/tools/parsevkctl-go/internal/planner/plan.go
+++ b/tools/parsevkctl-go/internal/planner/plan.go
@@ -1,0 +1,270 @@
+package planner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+)
+
+type OperationType string
+
+const (
+	OperationIssueCreate        OperationType = "Issue.Create"
+	OperationIssueClose         OperationType = "Issue.Close"
+	OperationProjectAddItem     OperationType = "Project.AddItem"
+	OperationProjectSetStatus   OperationType = "Project.SetStatus"
+	OperationGitFetch           OperationType = "Git.Fetch"
+	OperationGitSwitch          OperationType = "Git.Switch"
+	OperationGitPullFastForward OperationType = "Git.PullFastForward"
+	OperationGitCreateBranch    OperationType = "Git.CreateBranch"
+	OperationGitPushBranch      OperationType = "Git.PushBranch"
+	OperationPullRequestCreate  OperationType = "PullRequest.Create"
+	OperationPullRequestMerge   OperationType = "PullRequest.Merge"
+	OperationBranchDeleteLocal  OperationType = "Branch.DeleteLocal"
+	OperationBranchDeleteRemote OperationType = "Branch.DeleteRemote"
+)
+
+const originRemote = "origin"
+
+type Operation struct {
+	ID          string        `json:"id"`
+	Type        OperationType `json:"type"`
+	Description string        `json:"description"`
+	SafeToRetry bool          `json:"safeToRetry"`
+	Payload     any           `json:"payload,omitempty"`
+}
+
+type Plan struct {
+	Command    string      `json:"command"`
+	Issue      int         `json:"issue,omitempty"`
+	Operations []Operation `json:"operations"`
+}
+
+type StartTaskInput struct {
+	Issue         domain.Issue
+	DefaultBranch string
+	BranchName    string
+	TargetStatus  domain.ProjectStatus
+}
+
+type CreatePullRequestInput struct {
+	Issue             domain.Issue
+	BranchName        string
+	BaseBranch        string
+	Title             string
+	Body              string
+	TargetStatus      domain.ProjectStatus
+	DeleteLocalBranch bool
+}
+
+type ProjectStatusPayload struct {
+	IssueNumber int                  `json:"issueNumber"`
+	Status      domain.ProjectStatus `json:"status"`
+}
+
+type ProjectIssuePayload struct {
+	IssueNumber int `json:"issueNumber"`
+}
+
+type GitRefPayload struct {
+	Remote string `json:"remote"`
+	Branch string `json:"branch"`
+}
+
+type GitBranchPayload struct {
+	Branch string `json:"branch"`
+}
+
+type DeleteLocalBranchPayload struct {
+	Branch string `json:"branch"`
+	Force  bool   `json:"force"`
+}
+
+type PullRequestPayload struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+	Draft bool   `json:"draft"`
+}
+
+type MergePullRequestPayload struct {
+	Number       int    `json:"number"`
+	Method       string `json:"method"`
+	DeleteBranch bool   `json:"deleteBranch"`
+	Auto         bool   `json:"auto"`
+}
+
+func NewStartTaskPlan(input StartTaskInput) (Plan, error) {
+	issueNumber, err := validateIssue(input.Issue)
+	if err != nil {
+		return Plan{}, err
+	}
+	defaultBranch, err := validateNonEmpty("default branch", input.DefaultBranch)
+	if err != nil {
+		return Plan{}, err
+	}
+	branchName, err := validateNonEmpty("branch name", input.BranchName)
+	if err != nil {
+		return Plan{}, err
+	}
+	targetStatus, err := validateProjectStatus(input.TargetStatus)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	return Plan{
+		Command: "task start",
+		Issue:   issueNumber,
+		Operations: []Operation{
+			{
+				ID:          "project-set-status-" + statusID(targetStatus),
+				Type:        OperationProjectSetStatus,
+				Description: fmt.Sprintf("Set project status for issue #%d to %s", issueNumber, targetStatus),
+				SafeToRetry: true,
+				Payload:     ProjectStatusPayload{IssueNumber: issueNumber, Status: targetStatus},
+			},
+			{
+				ID:          "git-fetch-default-branch",
+				Type:        OperationGitFetch,
+				Description: fmt.Sprintf("Fetch origin/%s", defaultBranch),
+				SafeToRetry: true,
+				Payload:     GitRefPayload{Remote: originRemote, Branch: defaultBranch},
+			},
+			{
+				ID:          "git-switch-default-branch",
+				Type:        OperationGitSwitch,
+				Description: fmt.Sprintf("Switch to %s", defaultBranch),
+				SafeToRetry: true,
+				Payload:     GitBranchPayload{Branch: defaultBranch},
+			},
+			{
+				ID:          "git-pull-fast-forward-default-branch",
+				Type:        OperationGitPullFastForward,
+				Description: fmt.Sprintf("Pull %s with --ff-only from origin", defaultBranch),
+				SafeToRetry: true,
+				Payload:     GitRefPayload{Remote: originRemote, Branch: defaultBranch},
+			},
+			{
+				ID:          "git-create-task-branch",
+				Type:        OperationGitCreateBranch,
+				Description: fmt.Sprintf("Create task branch %s", branchName),
+				SafeToRetry: false,
+				Payload:     GitBranchPayload{Branch: branchName},
+			},
+		},
+	}, nil
+}
+
+func NewCreatePullRequestPlan(input CreatePullRequestInput) (Plan, error) {
+	issueNumber, err := validateIssue(input.Issue)
+	if err != nil {
+		return Plan{}, err
+	}
+	branchName, err := validateNonEmpty("branch name", input.BranchName)
+	if err != nil {
+		return Plan{}, err
+	}
+	baseBranch, err := validateNonEmpty("base branch", input.BaseBranch)
+	if err != nil {
+		return Plan{}, err
+	}
+	title, err := validateNonEmpty("pull request title", input.Title)
+	if err != nil {
+		return Plan{}, err
+	}
+	targetStatus, err := validateProjectStatus(input.TargetStatus)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	operations := []Operation{
+		{
+			ID:          "git-push-task-branch",
+			Type:        OperationGitPushBranch,
+			Description: fmt.Sprintf("Push task branch %s to origin", branchName),
+			SafeToRetry: true,
+			Payload:     GitRefPayload{Remote: originRemote, Branch: branchName},
+		},
+		{
+			ID:          "pull-request-create",
+			Type:        OperationPullRequestCreate,
+			Description: fmt.Sprintf("Create pull request %q from %s to %s", title, branchName, baseBranch),
+			SafeToRetry: false,
+			Payload: PullRequestPayload{
+				Title: title,
+				Body:  input.Body,
+				Head:  branchName,
+				Base:  baseBranch,
+			},
+		},
+		{
+			ID:          "project-set-status-" + statusID(targetStatus),
+			Type:        OperationProjectSetStatus,
+			Description: fmt.Sprintf("Set project status for issue #%d to %s", issueNumber, targetStatus),
+			SafeToRetry: true,
+			Payload:     ProjectStatusPayload{IssueNumber: issueNumber, Status: targetStatus},
+		},
+	}
+
+	if input.DeleteLocalBranch {
+		operations = append(operations, Operation{
+			ID:          "branch-delete-local-task-branch",
+			Type:        OperationBranchDeleteLocal,
+			Description: fmt.Sprintf("Delete local task branch %s", branchName),
+			SafeToRetry: true,
+			Payload:     DeleteLocalBranchPayload{Branch: branchName},
+		})
+	}
+
+	return Plan{
+		Command:    "task pr",
+		Issue:      issueNumber,
+		Operations: operations,
+	}, nil
+}
+
+func RenderDryRun(plan Plan) []string {
+	lines := make([]string, 0, len(plan.Operations)+1)
+	header := plan.Command
+	if plan.Issue > 0 {
+		header = fmt.Sprintf("%s #%d", plan.Command, plan.Issue)
+	}
+	lines = append(lines, header)
+
+	for i, operation := range plan.Operations {
+		lines = append(lines, fmt.Sprintf("%d. [%s] %s", i+1, operation.Type, operation.Description))
+	}
+
+	return lines
+}
+
+func validateIssue(issue domain.Issue) (int, error) {
+	if err := domain.ValidateTaskID(issue.ID); err != nil {
+		return 0, err
+	}
+
+	return int(issue.ID), nil
+}
+
+func validateNonEmpty(name string, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", fmt.Errorf("%s must not be empty", name)
+	}
+
+	return trimmed, nil
+}
+
+func validateProjectStatus(status domain.ProjectStatus) (domain.ProjectStatus, error) {
+	if status == "" || status == domain.ProjectStatusUnknown {
+		return "", fmt.Errorf("project status must not be empty or unknown")
+	}
+
+	return status, nil
+}
+
+func statusID(status domain.ProjectStatus) string {
+	return strings.ReplaceAll(strings.ToLower(string(status)), " ", "-")
+}

--- a/tools/parsevkctl-go/internal/planner/plan_test.go
+++ b/tools/parsevkctl-go/internal/planner/plan_test.go
@@ -1,0 +1,184 @@
+package planner
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+)
+
+func TestNewStartTaskPlanOperationOrder(t *testing.T) {
+	plan, err := NewStartTaskPlan(StartTaskInput{
+		Issue: domain.Issue{
+			ID:    111,
+			Title: "Add planner",
+		},
+		DefaultBranch: "fastapi-microservices-rewrite",
+		BranchName:    "feat/issue-111-planner",
+		TargetStatus:  domain.ProjectStatusInProgress,
+	})
+	if err != nil {
+		t.Fatalf("NewStartTaskPlan returned error: %v", err)
+	}
+
+	if plan.Command != "task start" {
+		t.Fatalf("Command = %q, want %q", plan.Command, "task start")
+	}
+	if plan.Issue != 111 {
+		t.Fatalf("Issue = %d, want 111", plan.Issue)
+	}
+
+	got := operationTypes(plan)
+	want := []OperationType{
+		OperationProjectSetStatus,
+		OperationGitFetch,
+		OperationGitSwitch,
+		OperationGitPullFastForward,
+		OperationGitCreateBranch,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("operation types = %#v, want %#v", got, want)
+	}
+
+	wantIDs := []string{
+		"project-set-status-in-progress",
+		"git-fetch-default-branch",
+		"git-switch-default-branch",
+		"git-pull-fast-forward-default-branch",
+		"git-create-task-branch",
+	}
+	if got := operationIDs(plan); !reflect.DeepEqual(got, wantIDs) {
+		t.Fatalf("operation IDs = %#v, want %#v", got, wantIDs)
+	}
+}
+
+func TestNewStartTaskPlanValidation(t *testing.T) {
+	issue := domain.Issue{ID: 111}
+
+	if _, err := NewStartTaskPlan(StartTaskInput{
+		Issue:         issue,
+		DefaultBranch: "",
+		BranchName:    "feat/issue-111-planner",
+		TargetStatus:  domain.ProjectStatusInProgress,
+	}); err == nil {
+		t.Fatal("NewStartTaskPlan with empty default branch returned nil error")
+	}
+
+	if _, err := NewStartTaskPlan(StartTaskInput{
+		Issue:         issue,
+		DefaultBranch: "fastapi-microservices-rewrite",
+		BranchName:    "",
+		TargetStatus:  domain.ProjectStatusInProgress,
+	}); err == nil {
+		t.Fatal("NewStartTaskPlan with empty branch returned nil error")
+	}
+}
+
+func TestNewCreatePullRequestPlanOperationOrder(t *testing.T) {
+	plan, err := NewCreatePullRequestPlan(CreatePullRequestInput{
+		Issue: domain.Issue{
+			ID:    111,
+			Title: "Add planner",
+		},
+		BranchName:   "feat/issue-111-planner",
+		BaseBranch:   "fastapi-microservices-rewrite",
+		Title:        "Go rewrite: add planner executor",
+		Body:         "Closes #111",
+		TargetStatus: domain.ProjectStatusReview,
+	})
+	if err != nil {
+		t.Fatalf("NewCreatePullRequestPlan returned error: %v", err)
+	}
+
+	got := operationTypes(plan)
+	want := []OperationType{
+		OperationGitPushBranch,
+		OperationPullRequestCreate,
+		OperationProjectSetStatus,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("operation types = %#v, want %#v", got, want)
+	}
+
+	wantIDs := []string{
+		"git-push-task-branch",
+		"pull-request-create",
+		"project-set-status-review",
+	}
+	if got := operationIDs(plan); !reflect.DeepEqual(got, wantIDs) {
+		t.Fatalf("operation IDs = %#v, want %#v", got, wantIDs)
+	}
+}
+
+func TestPlanJSONSerialization(t *testing.T) {
+	plan, err := NewCreatePullRequestPlan(CreatePullRequestInput{
+		Issue:        domain.Issue{ID: 111},
+		BranchName:   "feat/issue-111-planner",
+		BaseBranch:   "fastapi-microservices-rewrite",
+		Title:        "Go rewrite: add planner executor",
+		Body:         "Closes #111",
+		TargetStatus: domain.ProjectStatusReview,
+	})
+	if err != nil {
+		t.Fatalf("NewCreatePullRequestPlan returned error: %v", err)
+	}
+
+	data, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var decoded Plan
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if decoded.Command != plan.Command || decoded.Issue != plan.Issue {
+		t.Fatalf("decoded plan = %#v, want command %q issue %d", decoded, plan.Command, plan.Issue)
+	}
+	if len(decoded.Operations) != len(plan.Operations) {
+		t.Fatalf("decoded operations length = %d, want %d", len(decoded.Operations), len(plan.Operations))
+	}
+}
+
+func TestRenderDryRunOutput(t *testing.T) {
+	plan, err := NewStartTaskPlan(StartTaskInput{
+		Issue:         domain.Issue{ID: 111},
+		DefaultBranch: "fastapi-microservices-rewrite",
+		BranchName:    "feat/issue-111-planner",
+		TargetStatus:  domain.ProjectStatusInProgress,
+	})
+	if err != nil {
+		t.Fatalf("NewStartTaskPlan returned error: %v", err)
+	}
+
+	got := RenderDryRun(plan)
+	want := []string{
+		"task start #111",
+		"1. [Project.SetStatus] Set project status for issue #111 to In Progress",
+		"2. [Git.Fetch] Fetch origin/fastapi-microservices-rewrite",
+		"3. [Git.Switch] Switch to fastapi-microservices-rewrite",
+		"4. [Git.PullFastForward] Pull fastapi-microservices-rewrite with --ff-only from origin",
+		"5. [Git.CreateBranch] Create task branch feat/issue-111-planner",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RenderDryRun = %#v, want %#v", got, want)
+	}
+}
+
+func operationTypes(plan Plan) []OperationType {
+	types := make([]OperationType, len(plan.Operations))
+	for i, operation := range plan.Operations {
+		types[i] = operation.Type
+	}
+	return types
+}
+
+func operationIDs(plan Plan) []string {
+	ids := make([]string, len(plan.Operations))
+	for i, operation := range plan.Operations {
+		ids[i] = operation.ID
+	}
+	return ids
+}


### PR DESCRIPTION
Closes #111

## Summary
- Added internal/planner with deterministic task plans, dry-run rendering, and serial executor over typed git/github adapters.

## Test plan
- [ ] Not run
- [ ] Manual test
- [x] Automated tests

## Risk
- Low: internal Go rewrite package only; no user-facing task CLI commands added.

## Notes
Created via parsevkctl.