### PR TITLE
Go rewrite: audit and close remaining backend migration gaps

### DIFF
--- a/docs/PARSEVKCTL.md
+++ b/docs/PARSEVKCTL.md
@@ -2,7 +2,7 @@
 
 `parsevkctl` is the local task workflow helper for the `andr-235/parseVK`
 repository. The Go CLI in `tools/parsevkctl-go` is the canonical
-implementation.
+implementation for task lifecycle commands.
 
 The historical PowerShell entrypoint remains temporarily for compatibility:
 
@@ -114,6 +114,19 @@ Merge the linked pull request and finish the issue:
 .\tools\parsevkctl\parsevkctl.ps1 task merge 123
 ```
 
+Create a new task issue:
+
+```powershell
+.\tools\parsevkctl\parsevkctl.ps1 task create "Title" --body "Optional body"
+```
+
+Show task state or preview drift without writes:
+
+```powershell
+.\tools\parsevkctl\parsevkctl.ps1 task status 123
+.\tools\parsevkctl\parsevkctl.ps1 task sync 123
+```
+
 Preview write operations without mutating GitHub or local git state:
 
 ```powershell
@@ -138,6 +151,37 @@ Todo -> In Progress -> Review -> Done
 - `In Progress`: task is started and a task branch is created.
 - `Review`: pull request is open and ready for review.
 - `Done`: pull request is merged and the issue is closed.
+
+## Post-PR and Post-Merge Cleanup
+
+`task pr <issue>` creates the PR, moves the Project item to `Review`, then
+switches back to the configured default branch and pulls it with `--ff-only`.
+It does not delete the local task branch at PR time because the branch is not
+merged yet.
+
+`task merge <issue>` merges the linked PR and passes `--delete-branch` to
+GitHub CLI when `merge.deleteBranch` is `true`. If the command is run from the
+PR head branch, it switches back to the configured default branch, pulls with
+`--ff-only`, and deletes the local task branch with `git branch -d`.
+
+Protected branches such as `main`, `master`, and
+`fastapi-microservices-rewrite` are never deleted by the Git adapter.
+
+## Migration Status
+
+The Go rewrite is canonical for the documented workflow:
+
+```text
+config validate
+doctor
+task create -> task start -> task status/task sync -> task pr -> task merge
+--json output
+legacy wrapper delegation
+```
+
+The remaining known limitation is intentional: `task sync <issue>` is
+preview/read-only. `task sync <issue> --apply` is not part of the completed
+migration surface and exits with a preview-only error.
 
 ## Branch Naming
 

--- a/docs/PARSEVKCTL_GO_MIGRATION_AUDIT.md
+++ b/docs/PARSEVKCTL_GO_MIGRATION_AUDIT.md
@@ -1,0 +1,65 @@
+# parsevkctl Go Migration Audit
+
+Audit date: 2026-05-23.
+
+## Scope
+
+Issue #126 audited the final Go rewrite migration surface for `parsevkctl`.
+The Go CLI is the canonical implementation; the PowerShell entrypoint at
+`tools/parsevkctl/parsevkctl.ps1` is a legacy wrapper that delegates to the Go
+binary and preserves its exit code.
+
+## Command Parity
+
+Verified workflow surface:
+
+- `parsevkctl config validate`
+- `parsevkctl doctor`
+- `parsevkctl task create "Title" --body "..."`
+- `parsevkctl task start <issue>`
+- `parsevkctl task status <issue>`
+- `parsevkctl task sync <issue>` as preview/read-only
+- `parsevkctl task pr <issue>`
+- `parsevkctl task merge <issue>`
+- `parsevkctl --json ...`
+- `tools/parsevkctl/parsevkctl.ps1 ...`
+
+`task sync --apply` remains intentionally unsupported. It is not required for
+the completed migration because `task sync` is documented as preview/read-only.
+
+## Architecture Audit
+
+- Direct `git` shell calls are limited to `internal/git`.
+- Direct `gh` shell calls are limited to `internal/github`.
+- `internal/planner` remains side-effect free and only returns operation plans.
+- Write operations are applied by `planner.Executor` through typed adapters.
+- Project operations are implemented through GitHub CLI project commands and
+are exercised by `doctor`, `task status`, `task start`, `task pr`, and
+`task merge`.
+
+## Fixed Gaps
+
+- `task pr` now switches back to the configured default branch after PR
+  creation and pulls it with `--ff-only`.
+- `task pr` now leaves the local task branch in place because deleting an
+  unmerged PR branch is not safe.
+- `task merge` deletes the local task branch when run from the PR head branch
+  and `merge.deleteBranch` is enabled.
+- `doctor` now checks Project Status field availability directly instead of
+  probing a hard-coded issue item.
+
+## Remaining Gaps
+
+No blocking migration gaps were found for the documented core workflow:
+
+```text
+create -> start -> pr -> merge
+```
+
+Known limitations:
+
+- `task sync --apply` is intentionally preview-only and should remain a
+  separate future feature if write-based drift repair is needed.
+- `merge.requireChecks=true` still requires a check-status adapter before fully
+  automated merges can enforce CI status from Go. Current project config has
+  `merge.requireChecks=false`, so this does not block the current workflow.

--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -1,6 +1,8 @@
 # parsevkctl Go CLI
 
-Canonical implementation of parsevkctl.
+Canonical implementation of parsevkctl. New task workflow automation should use
+this Go CLI; `../parsevkctl/parsevkctl.ps1` is only a legacy compatibility
+wrapper.
 
 Build: go build ./cmd/parsevkctl
 Build local legacy-wrapper binary: ../parsevkctl/build.ps1
@@ -101,9 +103,9 @@ go run ./cmd/parsevkctl task merge 113
 
 `task start <issue>` loads the issue, validates that it is open, validates the lifecycle transition to `InProgress`, derives the task branch through `internal/branch`, sets Project status to `In Progress`, fetches the default branch, switches to it, pulls with `--ff-only`, and creates the task branch.
 
-`task pr <issue>` validates the current task branch, confirms the branch issue number matches the requested issue, checks that the working tree is clean and the branch is ahead of the default branch, pushes the branch, creates a PR with `Closes #<issue>` in the body, and sets Project status to `Review`. If an open PR already exists for the same branch/base, the command returns that PR instead of creating a duplicate.
+`task pr <issue>` validates the current task branch, confirms the branch issue number matches the requested issue, checks that the working tree is clean and the branch is ahead of the default branch, pushes the branch, creates a PR with `Closes #<issue>` in the body, sets Project status to `Review`, switches back to the default branch and pulls it with `--ff-only`. It keeps the local task branch after PR creation because that branch is not merged yet. If an open PR already exists for the same branch/base, the command returns that PR instead of creating a duplicate.
 
-`task merge <issue>` finds the linked PR, requires exactly one PR, rejects draft PRs and wrong base branches, respects `merge.requireChecks`, merges the PR, sets Project status to `Done`, closes the issue if needed, switches to the default branch when safe, and pulls with `--ff-only`.
+`task merge <issue>` finds the linked PR, requires exactly one PR, rejects draft PRs and wrong base branches, respects `merge.requireChecks`, merges the PR, sets Project status to `Done`, closes the issue if needed, switches to the default branch when safe, and pulls with `--ff-only`. When `merge.deleteBranch` is `true`, the merge operation asks GitHub to delete the remote PR branch and the local task branch is deleted with `git branch -d` when the command was run from that branch.
 
 Use `--dry-run` with any write command to render the operation plan without executing it:
 

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -115,7 +115,7 @@ func TestDoctorAllOK(t *testing.T) {
 
 func TestDoctorWarnsWhenProjectUnavailable(t *testing.T) {
 	deps := okDeps()
-	deps.GitHub.projectErr = github.ErrProjectNotImplemented
+	deps.GitHub.projectFieldErr = github.ErrProjectNotImplemented
 
 	result := RunDoctor(context.Background(), DoctorInput{
 		ConfigValidation: config.ValidationResult{Path: "config.json", Valid: true},
@@ -128,6 +128,24 @@ func TestDoctorWarnsWhenProjectUnavailable(t *testing.T) {
 		t.Fatalf("exit = %d, want 0", result.ExitCode)
 	}
 	assertCheck(t, result.Checks, "project-status", CheckWarn)
+	deps.assertNoWrites(t)
+}
+
+func TestDoctorChecksProjectFieldAvailabilityWithoutIssueStub(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.projectErr = errors.New("project item not found for issue #1")
+
+	result := RunDoctor(context.Background(), DoctorInput{
+		ConfigValidation: config.ValidationResult{Path: "config.json", Valid: true},
+		Config:           deps.Config,
+		Git:              deps.Git,
+		GitHub:           deps.GitHub,
+	})
+
+	if result.ExitCode != 0 {
+		t.Fatalf("exit = %d, want 0", result.ExitCode)
+	}
+	assertCheck(t, result.Checks, "project-status", CheckOK)
 	deps.assertNoWrites(t)
 }
 
@@ -346,7 +364,7 @@ func TestTaskPRDryRunPlan(t *testing.T) {
 	}
 
 	got := planOperationTypes(result.Plan.Operations)
-	want := []string{"Git.PushBranch", "PullRequest.Create", "Project.SetStatus"}
+	want := []string{"Git.PushBranch", "PullRequest.Create", "Project.SetStatus", "Git.Switch", "Git.PullFastForward"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("operations = %#v, want %#v", got, want)
 	}
@@ -401,6 +419,9 @@ func TestTaskMergeRejectsWrongBaseBranch(t *testing.T) {
 
 func TestTaskMergeDryRunPlan(t *testing.T) {
 	deps := okDeps()
+	deleteBranch := true
+	deps.Config.Merge.DeleteBranch = &deleteBranch
+	deps.Git.currentBranch = "feat/issue-112-add-read-only-task-commands"
 	deps.GitHub.prs = []domain.PullRequest{{
 		Number: 9,
 		State:  domain.PullRequestStateOpen,
@@ -419,7 +440,7 @@ func TestTaskMergeDryRunPlan(t *testing.T) {
 	}
 
 	got := planOperationTypes(result.Plan.Operations)
-	want := []string{"PullRequest.Merge", "Project.SetStatus", "Issue.Close", "Git.Switch", "Git.PullFastForward"}
+	want := []string{"PullRequest.Merge", "Project.SetStatus", "Issue.Close", "Git.Switch", "Git.PullFastForward", "Branch.DeleteLocal"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("operations = %#v, want %#v", got, want)
 	}
@@ -569,12 +590,13 @@ func (f *fakeGit) HasCommitsAhead(context.Context, string, string) (bool, error)
 }
 
 type fakeGitHub struct {
-	issue       domain.Issue
-	prs         []domain.PullRequest
-	project     domain.ProjectItem
-	projectErr  error
-	allowWrites bool
-	writeCalls  []string
+	issue           domain.Issue
+	prs             []domain.PullRequest
+	project         domain.ProjectItem
+	projectErr      error
+	projectFieldErr error
+	allowWrites     bool
+	writeCalls      []string
 }
 
 func (f *fakeGitHub) GetIssue(context.Context, int) (domain.Issue, error) {
@@ -630,6 +652,9 @@ func (f *fakeGitHub) SetProjectStatus(context.Context, int, domain.ProjectStatus
 		return nil
 	}
 	return errors.New("write call")
+}
+func (f *fakeGitHub) CheckProjectStatusField(context.Context) error {
+	return f.projectFieldErr
 }
 
 func planOperationTypes(operations []planner.Operation) []string {

--- a/tools/parsevkctl-go/internal/commands/doctor.go
+++ b/tools/parsevkctl-go/internal/commands/doctor.go
@@ -46,6 +46,10 @@ type DoctorCheck struct {
 	Message string      `json:"message"`
 }
 
+type projectStatusFieldChecker interface {
+	CheckProjectStatusField(ctx context.Context) error
+}
+
 func RunDoctorCommand(ctx context.Context, input DoctorRunInput) int {
 	result := RunDoctor(ctx, input.DoctorInput)
 	if err := renderDoctor(input.Stdout, result, input.JSON); err != nil {
@@ -108,7 +112,18 @@ func RunDoctor(ctx context.Context, input DoctorInput) DoctorResult {
 		checks = append(checks, DoctorCheck{Name: "default-branch", Status: CheckOK, Message: "default branch reference is readable"})
 	}
 
-	if _, err := input.GitHub.GetProjectItem(ctx, 1); err != nil {
+	if checker, ok := input.GitHub.(projectStatusFieldChecker); ok {
+		if err := checker.CheckProjectStatusField(ctx); err != nil {
+			status := CheckWarn
+			message := projectUnavailableMessage(err)
+			if !errors.Is(err, github.ErrProjectNotImplemented) {
+				message = "project status check failed: " + err.Error()
+			}
+			checks = append(checks, DoctorCheck{Name: "project-status", Status: status, Message: message})
+		} else {
+			checks = append(checks, DoctorCheck{Name: "project-status", Status: CheckOK, Message: "project status field is available"})
+		}
+	} else if _, err := input.GitHub.GetProjectItem(ctx, 1); err != nil {
 		status := CheckWarn
 		message := projectUnavailableMessage(err)
 		if !errors.Is(err, github.ErrProjectNotImplemented) {

--- a/tools/parsevkctl-go/internal/commands/write.go
+++ b/tools/parsevkctl-go/internal/commands/write.go
@@ -347,6 +347,7 @@ func BuildTaskMergePlan(ctx context.Context, input TaskIssueInput) (TaskMergePla
 		TargetStatus:       domain.ProjectStatusDone,
 		MergeMethod:        mergeStrategy(input.Config),
 		DeleteRemoteBranch: mergeDeletesBranch(input.Config),
+		DeleteLocalBranch:  mergeDeletesBranch(input.Config) && currentBranch == linked.Head && linked.Head != "",
 		CloseIssue:         true,
 		SyncDefaultBranch:  currentBranch != input.Config.DefaultBranch,
 	})

--- a/tools/parsevkctl-go/internal/github/shell.go
+++ b/tools/parsevkctl-go/internal/github/shell.go
@@ -282,6 +282,28 @@ func (adapter *ShellAdapter) SetProjectStatus(ctx context.Context, issueNumber i
 	return err
 }
 
+func (adapter *ShellAdapter) CheckProjectStatusField(ctx context.Context) error {
+	if err := adapter.validateProjectConfig(); err != nil {
+		return err
+	}
+	field, err := adapter.getStatusField(ctx)
+	if err != nil {
+		return err
+	}
+	required := []domain.ProjectStatus{
+		domain.ProjectStatusTodo,
+		domain.ProjectStatusInProgress,
+		domain.ProjectStatusReview,
+		domain.ProjectStatusDone,
+	}
+	for _, status := range required {
+		if !projectFieldHasOption(field, string(status)) {
+			return fmt.Errorf("status option not found: %s", status)
+		}
+	}
+	return nil
+}
+
 func (adapter *ShellAdapter) getPullRequest(ctx context.Context, number int) (domain.PullRequest, error) {
 	if err := validateNumber("pull request number", number); err != nil {
 		return domain.PullRequest{}, err
@@ -370,6 +392,15 @@ type projectField struct {
 type projectOption struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+}
+
+func projectFieldHasOption(field projectField, name string) bool {
+	for _, option := range field.Options {
+		if option.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func parseProjectItemsJSON(data []byte) (projectItemsJSON, error) {

--- a/tools/parsevkctl-go/internal/github/shell_test.go
+++ b/tools/parsevkctl-go/internal/github/shell_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/config"
 	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
 )
 
@@ -242,6 +243,35 @@ func TestProjectMethodsReturnNotImplemented(t *testing.T) {
 	if err := adapter.SetProjectStatus(context.Background(), 108, domain.ProjectStatusReview); !errors.Is(err, ErrProjectNotImplemented) {
 		t.Fatalf("SetProjectStatus error = %v, want ErrProjectNotImplemented", err)
 	}
+	if err := adapter.CheckProjectStatusField(context.Background()); !errors.Is(err, ErrProjectNotImplemented) {
+		t.Fatalf("CheckProjectStatusField error = %v, want ErrProjectNotImplemented", err)
+	}
+}
+
+func TestCheckProjectStatusFieldUsesConfiguredProject(t *testing.T) {
+	t.Parallel()
+
+	var got []string
+	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+		got = append([]string(nil), args...)
+		return commandResult{stdout: projectFieldsOutput()}, nil
+	})
+	adapter.config = config.Config{
+		Repo:          "andr-235/parseVK",
+		ProjectOwner:  "andr-235",
+		ProjectNumber: 2,
+		ProjectID:     "project-id",
+		ProjectTitle:  "parsevk development",
+	}
+
+	if err := adapter.CheckProjectStatusField(context.Background()); err != nil {
+		t.Fatalf("CheckProjectStatusField returned error: %v", err)
+	}
+
+	want := []string{"project", "field-list", "2", "--owner", "andr-235", "--limit", "100", "--format", "json"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
 }
 
 type fakeExitError struct {
@@ -265,4 +295,8 @@ func commandOutputFor(args []string) string {
 	}
 
 	return `{"number":108,"title":"Issue","state":"OPEN"}`
+}
+
+func projectFieldsOutput() string {
+	return `{"fields":[{"id":"field-id","name":"Status","options":[{"id":"todo","name":"Todo"},{"id":"in-progress","name":"In Progress"},{"id":"review","name":"Review"},{"id":"done","name":"Done"}]}]}`
 }

--- a/tools/parsevkctl-go/internal/planner/plan.go
+++ b/tools/parsevkctl-go/internal/planner/plan.go
@@ -58,13 +58,12 @@ type CreateTaskInput struct {
 }
 
 type CreatePullRequestInput struct {
-	Issue             domain.Issue
-	BranchName        string
-	BaseBranch        string
-	Title             string
-	Body              string
-	TargetStatus      domain.ProjectStatus
-	DeleteLocalBranch bool
+	Issue        domain.Issue
+	BranchName   string
+	BaseBranch   string
+	Title        string
+	Body         string
+	TargetStatus domain.ProjectStatus
 }
 
 type MergeTaskInput struct {
@@ -74,6 +73,7 @@ type MergeTaskInput struct {
 	TargetStatus       domain.ProjectStatus
 	MergeMethod        string
 	DeleteRemoteBranch bool
+	DeleteLocalBranch  bool
 	CloseIssue         bool
 	SyncDefaultBranch  bool
 }
@@ -279,16 +279,20 @@ func NewCreatePullRequestPlan(input CreatePullRequestInput) (Plan, error) {
 			SafeToRetry: true,
 			Payload:     ProjectStatusPayload{IssueNumber: issueNumber, Status: targetStatus},
 		},
-	}
-
-	if input.DeleteLocalBranch {
-		operations = append(operations, Operation{
-			ID:          "branch-delete-local-task-branch",
-			Type:        OperationBranchDeleteLocal,
-			Description: fmt.Sprintf("Delete local task branch %s", branchName),
+		{
+			ID:          "git-switch-default-branch",
+			Type:        OperationGitSwitch,
+			Description: fmt.Sprintf("Switch to %s", baseBranch),
 			SafeToRetry: true,
-			Payload:     DeleteLocalBranchPayload{Branch: branchName},
-		})
+			Payload:     GitBranchPayload{Branch: baseBranch},
+		},
+		{
+			ID:          "git-pull-fast-forward-default-branch",
+			Type:        OperationGitPullFastForward,
+			Description: fmt.Sprintf("Pull %s with --ff-only from origin", baseBranch),
+			SafeToRetry: true,
+			Payload:     GitRefPayload{Remote: originRemote, Branch: baseBranch},
+		},
 	}
 
 	return Plan{
@@ -370,6 +374,15 @@ func NewMergeTaskPlan(input MergeTaskInput) (Plan, error) {
 				Payload:     GitRefPayload{Remote: originRemote, Branch: defaultBranch},
 			},
 		)
+	}
+	if input.DeleteLocalBranch {
+		operations = append(operations, Operation{
+			ID:          "branch-delete-local-task-branch",
+			Type:        OperationBranchDeleteLocal,
+			Description: fmt.Sprintf("Delete local task branch %s", input.PullRequest.Head),
+			SafeToRetry: true,
+			Payload:     DeleteLocalBranchPayload{Branch: input.PullRequest.Head},
+		})
 	}
 
 	return Plan{

--- a/tools/parsevkctl-go/internal/planner/plan_test.go
+++ b/tools/parsevkctl-go/internal/planner/plan_test.go
@@ -96,6 +96,8 @@ func TestNewCreatePullRequestPlanOperationOrder(t *testing.T) {
 		OperationGitPushBranch,
 		OperationPullRequestCreate,
 		OperationProjectSetStatus,
+		OperationGitSwitch,
+		OperationGitPullFastForward,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("operation types = %#v, want %#v", got, want)
@@ -105,6 +107,8 @@ func TestNewCreatePullRequestPlanOperationOrder(t *testing.T) {
 		"git-push-task-branch",
 		"pull-request-create",
 		"project-set-status-review",
+		"git-switch-default-branch",
+		"git-pull-fast-forward-default-branch",
 	}
 	if got := operationIDs(plan); !reflect.DeepEqual(got, wantIDs) {
 		t.Fatalf("operation IDs = %#v, want %#v", got, wantIDs)


### PR DESCRIPTION
Closes #126

## Audit summary
- Confirmed the documented Go CLI surface for `config validate`, `doctor`, `task create`, `task start`, `task status`, `task sync` preview/read-only, `task pr`, `task merge`, `--json`, and the legacy PowerShell wrapper.
- Confirmed direct `git` and `gh` shell execution remains isolated to `internal/git` and `internal/github`; planner stays side-effect free and write operations go through executor/adapters.
- Confirmed Project integration works for #126: status moved `In Progress` -> `Review`, `task status` reads Project status, and `doctor` now validates the Project Status field directly.

## Fixed gaps
- `task pr` now returns to the configured default branch and pulls it with `--ff-only` after creating the PR and moving Project status to `Review`.
- `task merge` now deletes the local task branch after switching back to default when run from the PR head branch and `merge.deleteBranch` is enabled.
- `doctor` no longer probes Project support through a hard-coded issue #1 item; it checks Status field availability and required Kanban options.
- Added `docs/PARSEVKCTL_GO_MIGRATION_AUDIT.md` with the audit result, fixed gaps, and known limitations.

## Follow-up issues
- None created. No blocking migration gaps remain for the documented core workflow.
- Known limitation kept documented: `task sync --apply` is intentionally unsupported because `task sync` is preview/read-only.
- Known limitation kept documented: `merge.requireChecks=true` still needs a check-status adapter before automated CI enforcement; current config has `merge.requireChecks=false`.

## Test results
- `go test ./...`
- `go build ./cmd/parsevkctl`
- `./tools/parsevkctl/build.ps1`
- `Invoke-Pester -Path ./tools/parsevkctl/parsevkctl.Tests.ps1 -PassThru` (3 passed)
- Smoke/manual: `parsevkctl config validate`, `parsevkctl doctor`, `parsevkctl --json doctor`, `parsevkctl --dry-run task create`, `parsevkctl task status 126`, `parsevkctl task sync 126`, `parsevkctl --dry-run task pr 126`, `parsevkctl task pr 126`