### PR TITLE
parsevkctl: сделать cleanup отсутствующей local branch идемпотентным

### DIFF
--- a/tools/parsevkctl-go/internal/git/errors.go
+++ b/tools/parsevkctl-go/internal/git/errors.go
@@ -33,14 +33,3 @@ func (err CommandError) Error() string {
 func (err CommandError) Unwrap() error {
 	return err.Err
 }
-
-func isLocalBranchNotFound(err error, branch string) bool {
-	var commandErr CommandError
-	if !errors.As(err, &commandErr) {
-		return false
-	}
-
-	branch = strings.TrimSpace(branch)
-	output := strings.ToLower(commandErr.Stderr + "\n" + commandErr.Stdout)
-	return strings.Contains(output, "branch '"+strings.ToLower(branch)+"' not found")
-}

--- a/tools/parsevkctl-go/internal/git/errors.go
+++ b/tools/parsevkctl-go/internal/git/errors.go
@@ -1,9 +1,12 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
+
+var ErrLocalBranchNotFound = errors.New("local branch not found")
 
 type CommandError struct {
 	Operation string
@@ -29,4 +32,15 @@ func (err CommandError) Error() string {
 
 func (err CommandError) Unwrap() error {
 	return err.Err
+}
+
+func isLocalBranchNotFound(err error, branch string) bool {
+	var commandErr CommandError
+	if !errors.As(err, &commandErr) {
+		return false
+	}
+
+	branch = strings.TrimSpace(branch)
+	output := strings.ToLower(commandErr.Stderr + "\n" + commandErr.Stdout)
+	return strings.Contains(output, "branch '"+strings.ToLower(branch)+"' not found")
 }

--- a/tools/parsevkctl-go/internal/git/shell.go
+++ b/tools/parsevkctl-go/internal/git/shell.go
@@ -107,6 +107,9 @@ func (adapter *ShellAdapter) DeleteLocalBranch(ctx context.Context, branch strin
 	}
 
 	_, err := adapter.runGit(ctx, "delete local branch", "branch", deleteFlag, branch)
+	if isLocalBranchNotFound(err, branch) {
+		return fmt.Errorf("%w: %v", ErrLocalBranchNotFound, err)
+	}
 	return err
 }
 

--- a/tools/parsevkctl-go/internal/git/shell.go
+++ b/tools/parsevkctl-go/internal/git/shell.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -107,7 +108,12 @@ func (adapter *ShellAdapter) DeleteLocalBranch(ctx context.Context, branch strin
 	}
 
 	_, err := adapter.runGit(ctx, "delete local branch", "branch", deleteFlag, branch)
-	if isLocalBranchNotFound(err, branch) {
+	if err == nil {
+		return nil
+	}
+
+	exists, existsErr := adapter.localBranchExists(ctx, branch)
+	if existsErr == nil && !exists {
 		return fmt.Errorf("%w: %v", ErrLocalBranchNotFound, err)
 	}
 	return err
@@ -168,6 +174,27 @@ func (adapter *ShellAdapter) runGit(ctx context.Context, operation string, args 
 	}
 
 	return result, nil
+}
+
+func (adapter *ShellAdapter) localBranchExists(ctx context.Context, branch string) (bool, error) {
+	_, err := adapter.runGit(ctx, "verify local branch", "show-ref", "--verify", "--quiet", "refs/heads/"+strings.TrimSpace(branch))
+	if err == nil {
+		return true, nil
+	}
+	if exitCodeOf(err) == 1 {
+		return false, nil
+	}
+	return false, err
+}
+
+func exitCodeOf(err error) int {
+	var exitErr interface {
+		ExitCode() int
+	}
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }
 
 func runCommand(ctx context.Context, name string, args ...string) (commandResult, error) {

--- a/tools/parsevkctl-go/internal/git/shell_test.go
+++ b/tools/parsevkctl-go/internal/git/shell_test.go
@@ -73,6 +73,19 @@ func TestDeleteLocalBranchRejectsProtectedBranches(t *testing.T) {
 	}
 }
 
+func TestDeleteLocalBranchClassifiesMissingBranch(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
+		return commandResult{stderr: "error: branch 'feature' not found."}, errors.New("exit status 1")
+	})
+
+	err := adapter.DeleteLocalBranch(context.Background(), "feature", false)
+	if !errors.Is(err, ErrLocalBranchNotFound) {
+		t.Fatalf("error = %v, want ErrLocalBranchNotFound", err)
+	}
+}
+
 func TestEmptyBranchValidation(t *testing.T) {
 	t.Parallel()
 

--- a/tools/parsevkctl-go/internal/git/shell_test.go
+++ b/tools/parsevkctl-go/internal/git/shell_test.go
@@ -76,13 +76,61 @@ func TestDeleteLocalBranchRejectsProtectedBranches(t *testing.T) {
 func TestDeleteLocalBranchClassifiesMissingBranch(t *testing.T) {
 	t.Parallel()
 
-	adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
-		return commandResult{stderr: "error: branch 'feature' not found."}, errors.New("exit status 1")
+	var got [][]string
+	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+		got = append(got, append([]string(nil), args...))
+		if len(args) >= 2 && args[0] == "branch" {
+			return commandResult{stderr: "error: branch 'feature' not found."}, errors.New("exit status 1")
+		}
+		return commandResult{}, fakeExitError{code: 1}
 	})
 
 	err := adapter.DeleteLocalBranch(context.Background(), "feature", false)
 	if !errors.Is(err, ErrLocalBranchNotFound) {
 		t.Fatalf("error = %v, want ErrLocalBranchNotFound", err)
+	}
+
+	want := [][]string{
+		{"branch", "-d", "feature"},
+		{"show-ref", "--verify", "--quiet", "refs/heads/feature"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestDeleteLocalBranchClassifiesLocalizedMissingBranch(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+		if len(args) >= 2 && args[0] == "branch" {
+			return commandResult{stderr: "ошибка: ветка не найдена"}, errors.New("exit status 1")
+		}
+		return commandResult{}, fakeExitError{code: 1}
+	})
+
+	err := adapter.DeleteLocalBranch(context.Background(), "feature", false)
+	if !errors.Is(err, ErrLocalBranchNotFound) {
+		t.Fatalf("error = %v, want ErrLocalBranchNotFound", err)
+	}
+}
+
+func TestDeleteLocalBranchKeepsFailuresStrictWhenBranchStillExists(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+		if len(args) >= 2 && args[0] == "branch" {
+			return commandResult{stderr: "permission denied"}, errors.New("exit status 1")
+		}
+		return commandResult{}, nil
+	})
+
+	err := adapter.DeleteLocalBranch(context.Background(), "feature", false)
+	if err == nil {
+		t.Fatalf("expected delete failure")
+	}
+	if errors.Is(err, ErrLocalBranchNotFound) {
+		t.Fatalf("error = %v, must not be ErrLocalBranchNotFound", err)
 	}
 }
 
@@ -264,4 +312,16 @@ func TestCommandErrorsIncludeOperationAndOutput(t *testing.T) {
 			t.Fatalf("error = %q, want it to contain %q", message, want)
 		}
 	}
+}
+
+type fakeExitError struct {
+	code int
+}
+
+func (err fakeExitError) Error() string {
+	return "exit status"
+}
+
+func (err fakeExitError) ExitCode() int {
+	return err.code
 }

--- a/tools/parsevkctl-go/internal/github/shell.go
+++ b/tools/parsevkctl-go/internal/github/shell.go
@@ -193,10 +193,14 @@ func (adapter *ShellAdapter) GetProjectItem(ctx context.Context, issueNumber int
 	if err := adapter.validateProjectConfig(); err != nil {
 		return domain.ProjectItem{}, err
 	}
+	owner, err := adapter.projectOwnerArg(ctx)
+	if err != nil {
+		return domain.ProjectItem{}, err
+	}
 
 	result, err := adapter.runGH(ctx, "list project items",
 		"project", "item-list", strconv.Itoa(adapter.config.ProjectNumber),
-		"--owner", adapter.config.ProjectOwner,
+		"--owner", owner,
 		"--limit", "200",
 		"--format", "json",
 	)
@@ -345,9 +349,14 @@ func (adapter *ShellAdapter) validateProjectConfig() error {
 }
 
 func (adapter *ShellAdapter) getStatusField(ctx context.Context) (projectField, error) {
+	owner, err := adapter.projectOwnerArg(ctx)
+	if err != nil {
+		return projectField{}, err
+	}
+
 	result, err := adapter.runGH(ctx, "list project fields",
 		"project", "field-list", strconv.Itoa(adapter.config.ProjectNumber),
-		"--owner", adapter.config.ProjectOwner,
+		"--owner", owner,
 		"--limit", "100",
 		"--format", "json",
 	)
@@ -364,6 +373,22 @@ func (adapter *ShellAdapter) getStatusField(ctx context.Context) (projectField, 
 		}
 	}
 	return projectField{}, fmt.Errorf("project field not found: Status")
+}
+
+func (adapter *ShellAdapter) projectOwnerArg(ctx context.Context) (string, error) {
+	owner := strings.TrimSpace(adapter.config.ProjectOwner)
+	if owner == "@me" {
+		return owner, nil
+	}
+
+	result, err := adapter.runGH(ctx, "get authenticated user", "api", "user", "--jq", ".login")
+	if err != nil {
+		return "", err
+	}
+	if strings.EqualFold(strings.TrimSpace(result.stdout), owner) {
+		return "@me", nil
+	}
+	return owner, nil
 }
 
 type projectItemsJSON struct {

--- a/tools/parsevkctl-go/internal/github/shell_test.go
+++ b/tools/parsevkctl-go/internal/github/shell_test.go
@@ -251,9 +251,12 @@ func TestProjectMethodsReturnNotImplemented(t *testing.T) {
 func TestCheckProjectStatusFieldUsesConfiguredProject(t *testing.T) {
 	t.Parallel()
 
-	var got []string
+	var got [][]string
 	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
-		got = append([]string(nil), args...)
+		got = append(got, append([]string(nil), args...))
+		if len(args) >= 2 && args[0] == "api" && args[1] == "user" {
+			return commandResult{stdout: "andr-235"}, nil
+		}
 		return commandResult{stdout: projectFieldsOutput()}, nil
 	})
 	adapter.config = config.Config{
@@ -268,7 +271,42 @@ func TestCheckProjectStatusFieldUsesConfiguredProject(t *testing.T) {
 		t.Fatalf("CheckProjectStatusField returned error: %v", err)
 	}
 
-	want := []string{"project", "field-list", "2", "--owner", "andr-235", "--limit", "100", "--format", "json"}
+	want := [][]string{
+		{"api", "user", "--jq", ".login"},
+		{"project", "field-list", "2", "--owner", "@me", "--limit", "100", "--format", "json"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
+func TestCheckProjectStatusFieldKeepsOrganizationOwner(t *testing.T) {
+	t.Parallel()
+
+	var got [][]string
+	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+		got = append(got, append([]string(nil), args...))
+		if len(args) >= 2 && args[0] == "api" && args[1] == "user" {
+			return commandResult{stdout: "andr-235"}, nil
+		}
+		return commandResult{stdout: projectFieldsOutput()}, nil
+	})
+	adapter.config = config.Config{
+		Repo:          "parsevk-org/parseVK",
+		ProjectOwner:  "parsevk-org",
+		ProjectNumber: 2,
+		ProjectID:     "project-id",
+		ProjectTitle:  "parsevk development",
+	}
+
+	if err := adapter.CheckProjectStatusField(context.Background()); err != nil {
+		t.Fatalf("CheckProjectStatusField returned error: %v", err)
+	}
+
+	want := [][]string{
+		{"api", "user", "--jq", ".login"},
+		{"project", "field-list", "2", "--owner", "parsevk-org", "--limit", "100", "--format", "json"},
+	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %#v, want %#v", got, want)
 	}

--- a/tools/parsevkctl-go/internal/planner/executor.go
+++ b/tools/parsevkctl-go/internal/planner/executor.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
@@ -165,7 +166,11 @@ func (e Executor) executeOperation(ctx context.Context, operation Operation, cre
 		if err != nil {
 			return ExecutionResult{}, err
 		}
-		return ExecutionResult{}, e.Git.DeleteLocalBranch(ctx, payload.Branch, payload.Force)
+		err = e.Git.DeleteLocalBranch(ctx, payload.Branch, payload.Force)
+		if errors.Is(err, git.ErrLocalBranchNotFound) {
+			return ExecutionResult{}, nil
+		}
+		return ExecutionResult{}, err
 	case OperationBranchDeleteRemote:
 		payload, err := payloadAs[GitRefPayload](operation.Payload)
 		if err != nil {

--- a/tools/parsevkctl-go/internal/planner/executor_test.go
+++ b/tools/parsevkctl-go/internal/planner/executor_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/git"
 	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/github"
 )
 
@@ -87,6 +88,56 @@ func TestExecutorCallsAdaptersInExpectedOrder(t *testing.T) {
 	}
 	if !reflect.DeepEqual(recorder.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", recorder.calls, want)
+	}
+}
+
+func TestExecutorTreatsMissingLocalBranchCleanupAsNoop(t *testing.T) {
+	fakeGit := &fakeGitAdapter{failOn: "DeleteLocalBranch", failErr: git.ErrLocalBranchNotFound}
+	executor := Executor{Git: fakeGit, GitHub: &fakeGitHubAdapter{}}
+	plan := Plan{
+		Command: "task merge",
+		Issue:   129,
+		Operations: []Operation{
+			{
+				ID:      "branch-delete-local-task-branch",
+				Type:    OperationBranchDeleteLocal,
+				Payload: DeleteLocalBranchPayload{Branch: "feat/issue-129-cleanup"},
+			},
+		},
+	}
+
+	if err := executor.Execute(context.Background(), plan); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	wantGitCalls := []string{"DeleteLocalBranch:feat/issue-129-cleanup"}
+	if !reflect.DeepEqual(fakeGit.calls, wantGitCalls) {
+		t.Fatalf("git calls = %#v, want %#v", fakeGit.calls, wantGitCalls)
+	}
+}
+
+func TestExecutorKeepsDeleteLocalBranchFailuresStrict(t *testing.T) {
+	failErr := errors.New("permission denied")
+	fakeGit := &fakeGitAdapter{failOn: "DeleteLocalBranch", failErr: failErr}
+	executor := Executor{Git: fakeGit, GitHub: &fakeGitHubAdapter{}}
+	plan := Plan{
+		Command: "task merge",
+		Issue:   129,
+		Operations: []Operation{
+			{
+				ID:      "branch-delete-local-task-branch",
+				Type:    OperationBranchDeleteLocal,
+				Payload: DeleteLocalBranchPayload{Branch: "feat/issue-129-cleanup"},
+			},
+		},
+	}
+
+	err := executor.Execute(context.Background(), plan)
+	if err == nil {
+		t.Fatal("Execute returned nil error")
+	}
+	if !errors.Is(err, failErr) {
+		t.Fatalf("Execute error = %v, want %v", err, failErr)
 	}
 }
 


### PR DESCRIPTION
Closes #129

## Root cause
`parsevkctl task merge` завершал успешный merge workflow ошибкой на финальном cleanup-шаге `Branch.DeleteLocal`, если локальная PR head branch уже была удалена. `git branch -d <branch>` возвращал `branch not found`, а executor трактовал это как обычный fatal git failure.

Во время создания этого PR проявился второй lifecycle blocker: Project-команды `gh project field-list/item-list --owner andr-235` падали с `unknown owner type`, потому что для user projects GitHub CLI ожидает `--owner @me`, а не login текущего пользователя.

## Что изменено
- Добавлена точечная классификация missing local branch в `internal/git` через `ErrLocalBranchNotFound`.
- `planner.Executor` теперь считает `ErrLocalBranchNotFound` успешным no-op только для операции `Branch.DeleteLocal`.
- GitHub Project owner теперь нормализуется: если `projectOwner` совпадает с текущим `gh` user login, `parsevkctl` передаёт в `gh project` значение `@me`.
- Organization owner остаётся literal login и не переписывается.

## No-op теперь
- Только cleanup local branch, когда Git сообщает `branch '<name>' not found` для удаляемой локальной task/PR head branch.

## Всё ещё strict
- protected branch;
- permission/git failures;
- неверная или пустая ветка;
- ошибки remote branch cleanup;
- draft PR, wrong base, failed checks policy и остальные merge guardrails;
- GitHub Project ошибки, не связанные с owner-normalization.

## Test results
- `go test ./internal/git ./internal/planner`
- `go test ./internal/github`
- `go test ./...`
- `go build ./cmd/parsevkctl`
- `go test ./internal/git -run TestDeleteLocalBranchClassifiesMissingBranch`
- `parsevkctl doctor`
- `parsevkctl task pr 129` → existing PR detected without Project owner failure