### PR TITLE
feat(content): migrate authors groups read parity

### DIFF
--- a/docs/FASTAPI_MIG_004_AUTHORS_GROUPS_PARITY.md
+++ b/docs/FASTAPI_MIG_004_AUTHORS_GROUPS_PARITY.md
@@ -1,0 +1,27 @@
+# FASTAPI-MIG-004 Authors/Groups Parity
+
+Issue: #148
+
+## Endpoint map
+
+| Legacy NestJS endpoint | FastAPI/gateway endpoint | Status |
+|---|---|---|
+| `GET /authors` | `GET /api/v1/content/authors` | migrated: list, search, verified filter, city empty-state handling, sort, offset pagination |
+| `GET /authors/:vkUserId` | `GET /api/v1/content/authors/:vkUserId` | migrated: detail contract from content projection |
+| `POST /authors/refresh` | none | follow-up: requires authors saver/VK refresh dependency outside content-service |
+| `DELETE /authors/:vkUserId` | none | follow-up: legacy deletes Author plus related comments; content projection is read-model only |
+| `PATCH /authors/:vkUserId/verify` | none | follow-up: `verifiedAt` is not projected into content-service yet |
+| `GET /groups` | `GET /api/v1/content/groups` | migrated: list, search filter, sort, page pagination |
+| `GET /groups/:vkGroupId` | `GET /api/v1/content/groups/:vkGroupId` | migrated: detail contract from content projection |
+| `GET /groups/search?query` | `GET /api/v1/content/groups/search?q=` | migrated: read-model search by name, screen name, VK id |
+| `POST /groups/save` | none | follow-up: requires VK API write/upsert dependency; remains on NestJS |
+| `POST /groups/upload` | none | follow-up: bulk save depends on VK API and throttling behavior; remains on NestJS |
+| `DELETE /groups/:id` | none | follow-up: destructive write operation remains on NestJS |
+| `DELETE /groups/all` | none | follow-up: destructive write operation remains on NestJS |
+| `GET /groups/search/region` | none | follow-up: depends on VK region search implementation; remains on NestJS |
+
+## Notes
+
+- Authors photo-analysis summary enrichment is best-effort. If `CONTENT_PHOTO_ANALYSIS_BASE_URL` is not configured, times out, or returns an error, authors endpoints still return the base read model with `summary: null`.
+- The content-service read model currently contains a smaller VK projection than the legacy Prisma model. Missing fields are preserved as nullable legacy keys to keep frontend rendering stable while richer projection work remains a follow-up.
+- Frontend read clients now use gateway/FastAPI for authors list/details and groups list. Write/admin operations still call the legacy NestJS API.

--- a/docs/FASTAPI_MIG_004_AUTHORS_GROUPS_PARITY.md
+++ b/docs/FASTAPI_MIG_004_AUTHORS_GROUPS_PARITY.md
@@ -6,7 +6,7 @@ Issue: #148
 
 | Legacy NestJS endpoint | FastAPI/gateway endpoint | Status |
 |---|---|---|
-| `GET /authors` | `GET /api/v1/content/authors` | migrated: list, search, verified filter, city empty-state handling, sort, offset pagination |
+| `GET /authors` | `GET /api/v1/content/authors` | migrated: list, search, `fullName`/`updatedAt` sorting, offset pagination |
 | `GET /authors/:vkUserId` | `GET /api/v1/content/authors/:vkUserId` | migrated: detail contract from content projection |
 | `POST /authors/refresh` | none | follow-up: requires authors saver/VK refresh dependency outside content-service |
 | `DELETE /authors/:vkUserId` | none | follow-up: legacy deletes Author plus related comments; content projection is read-model only |
@@ -24,4 +24,6 @@ Issue: #148
 
 - Authors photo-analysis summary enrichment is best-effort. If `CONTENT_PHOTO_ANALYSIS_BASE_URL` is not configured, times out, or returns an error, authors endpoints still return the base read model with `summary: null`.
 - The content-service read model currently contains a smaller VK projection than the legacy Prisma model. Missing fields are preserved as nullable legacy keys to keep frontend rendering stable while richer projection work remains a follow-up.
-- Frontend read clients now use gateway/FastAPI for authors list/details and groups list. Write/admin operations still call the legacy NestJS API.
+- Direct FastAPI author reads reject projection-limited params with HTTP 400: `city`, `verified`, and `sortBy` values other than `fullName` or `updatedAt`.
+- Frontend authors reads use gateway/FastAPI only for projection-supported requests: no `city`, no `verified`, and no unsupported `sortBy`. City/verified filters and counters/lastSeen/verified sorting still route to legacy NestJS until richer author projection is available.
+- Frontend groups reads use gateway/FastAPI. Write/admin operations still call the legacy NestJS API.

--- a/front/src/api/authors/authors.api.test.ts
+++ b/front/src/api/authors/authors.api.test.ts
@@ -54,7 +54,7 @@ describe('authors api migration routing', () => {
     await authorsService.fetchAuthors({ offset: 20, limit: 10 })
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/api/v1/content/authors?page=3&limit=10',
+      '/api/v1/content/authors?offset=20&limit=10',
       expect.any(Object)
     )
   })
@@ -98,8 +98,82 @@ describe('authors api migration routing', () => {
   it('keeps filtered authors on legacy authors api', async () => {
     const { authorsService } = await import('./authors.api')
 
-    await authorsService.fetchAuthors({ limit: 10, search: 'ivan' })
+    await authorsService.fetchAuthors({ limit: 10, city: 'Yakutsk' })
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/authors?limit=10&search=ivan', expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledWith('/api/authors?limit=10&city=Yakutsk', expect.any(Object))
+  })
+
+  it('keeps verified filter on legacy authors api', async () => {
+    const { authorsService } = await import('./authors.api')
+
+    await authorsService.fetchAuthors({ limit: 10, verified: false })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/authors?limit=10&verified=false', expect.any(Object))
+  })
+
+  it('keeps unsupported author sort fields on legacy authors api', async () => {
+    const { authorsService } = await import('./authors.api')
+
+    await authorsService.fetchAuthors({ limit: 10, sortBy: 'photosCount', sortOrder: 'desc' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/authors?limit=10&sortBy=photosCount&sortOrder=desc',
+      expect.any(Object)
+    )
+  })
+
+  it('uses content gateway for projection-supported author search and sort', async () => {
+    const { authorsService } = await import('./authors.api')
+
+    await authorsService.fetchAuthors({ limit: 10, search: 'ivan', sortBy: 'fullName' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/content/authors?limit=10&search=ivan&sortBy=fullName',
+      expect.any(Object)
+    )
+  })
+
+  it('normalizes malformed photo-analysis summaries', async () => {
+    const { authorsService } = await import('./authors.api')
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: 1,
+              vkUserId: 100,
+              firstName: 'Test',
+              lastName: 'User',
+              fullName: 'Test User',
+              photo50: null,
+              photo100: null,
+              photo200: null,
+              domain: null,
+              screenName: null,
+              profileUrl: null,
+              city: null,
+              summary: { total: 1, suspicious: 0, categories: null, levels: {} },
+              photosCount: null,
+              audiosCount: null,
+              videosCount: null,
+              friendsCount: null,
+              followersCount: null,
+              lastSeenAt: null,
+              verifiedAt: null,
+              isVerified: false,
+            },
+          ],
+          total: 1,
+          hasMore: false,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+
+    const result = await authorsService.fetchAuthors({ limit: 10 })
+
+    expect(result.items[0].summary.categories).toEqual([])
+    expect(result.items[0].summary.levels).toEqual([])
   })
 })

--- a/front/src/api/authors/authors.api.ts
+++ b/front/src/api/authors/authors.api.ts
@@ -75,78 +75,7 @@ const mapAuthorDetails = (author: AuthorDetailsResponse): AuthorDetails => ({
   updatedAt: author.updatedAt,
 })
 
-type ContentPageDto<T> = {
-  items: T[]
-  total: number
-  page: number
-  limit: number
-  hasMore: boolean
-}
-
-type ContentAuthorDto = {
-  id: number
-  vkAuthorId: number
-  type?: string | null
-  displayName?: string | null
-  updatedAt?: string | null
-}
-
 const CONTENT_AUTHORS_API_URL = `${GATEWAY_API_URL}/v1/content/authors`
-
-const hasLegacyOnlyAuthorFilters = (params: {
-  search?: string
-  city?: string
-  verified?: boolean
-  sortBy?: AuthorSortField
-  sortOrder?: AuthorSortOrder
-}): boolean =>
-  Boolean(
-    params.search?.trim() ||
-      params.city?.trim() ||
-      params.verified !== undefined ||
-      params.sortBy ||
-      params.sortOrder
-  )
-
-const offsetToPage = (offset = 0, limit = 20): number => Math.floor(offset / limit) + 1
-
-const splitDisplayName = (displayName: string): { firstName: string; lastName: string } => {
-  const [firstName = '', ...rest] = displayName.trim().split(/\s+/)
-  return { firstName, lastName: rest.join(' ') }
-}
-
-const mapContentAuthor = (author: ContentAuthorDto): AuthorDetailsResponse => {
-  const displayName = author.displayName?.trim() || `VK ${author.vkAuthorId}`
-  const { firstName, lastName } = splitDisplayName(displayName)
-  const updatedAt = author.updatedAt ?? new Date(0).toISOString()
-
-  return {
-    id: author.id,
-    vkUserId: author.vkAuthorId,
-    firstName,
-    lastName,
-    fullName: displayName,
-    photo50: null,
-    photo100: null,
-    photo200: null,
-    domain: null,
-    screenName: null,
-    profileUrl: `https://vk.com/id${author.vkAuthorId}`,
-    city: null,
-    country: null,
-    summary: createEmptyPhotoAnalysisSummary(),
-    photosCount: null,
-    audiosCount: null,
-    videosCount: null,
-    friendsCount: null,
-    followersCount: null,
-    lastSeenAt: null,
-    verifiedAt: null,
-    isVerified: false,
-    createdAt: updatedAt,
-    updatedAt,
-  }
-}
 
 export const authorsService = {
   async fetchAuthors(
@@ -161,22 +90,6 @@ export const authorsService = {
     } = {}
   ): Promise<AuthorListResponse> {
     try {
-      if (!hasLegacyOnlyAuthorFilters(params)) {
-        const limit = params.limit ?? 20
-        const page = offsetToPage(params.offset, limit)
-        const response = await createRequest(`${CONTENT_AUTHORS_API_URL}?page=${page}&limit=${limit}`)
-        const data = await handleResponse<ContentPageDto<ContentAuthorDto>>(
-          response,
-          'Failed to fetch authors'
-        )
-
-        return {
-          items: data.items.map((author) => mapAuthorCard(mapContentAuthor(author))),
-          total: data.total,
-          hasMore: data.hasMore,
-        }
-      }
-
       const query = buildQueryString({
         offset: params.offset,
         limit: params.limit,
@@ -186,7 +99,7 @@ export const authorsService = {
         sortBy: params.sortBy,
         sortOrder: params.sortOrder,
       })
-      const url = query ? `${API_URL}/authors?${query}` : `${API_URL}/authors`
+      const url = query ? `${CONTENT_AUTHORS_API_URL}?${query}` : CONTENT_AUTHORS_API_URL
       const response = await createRequest(url)
 
       const data = await handleResponse<AuthorsListResponse>(
@@ -207,11 +120,11 @@ export const authorsService = {
   async getAuthorDetails(vkUserId: number): Promise<AuthorDetails> {
     try {
       const response = await createRequest(`${CONTENT_AUTHORS_API_URL}/${vkUserId}`)
-      const data = await handleResponse<ContentAuthorDto>(
+      const data = await handleResponse<AuthorDetailsResponse>(
         response,
         'Не удалось загрузить данные пользователя'
       )
-      return mapAuthorDetails(mapContentAuthor(data))
+      return mapAuthorDetails(data)
     } catch (error) {
       toast.error('Не удалось загрузить данные пользователя')
       throw error

--- a/front/src/api/authors/authors.api.ts
+++ b/front/src/api/authors/authors.api.ts
@@ -24,13 +24,16 @@ const normalizeSummary = (summary?: PhotoAnalysisSummary | null): PhotoAnalysisS
     return fallback
   }
 
+  const summaryCategories = Array.isArray(summary.categories) ? summary.categories : []
+  const summaryLevels = Array.isArray(summary.levels) ? summary.levels : []
+
   const categories = fallback.categories.map((category) => {
-    const existing = summary.categories.find((item) => item.name === category.name)
+    const existing = summaryCategories.find((item) => item.name === category.name)
     return existing ? { ...existing } : { ...category }
   })
 
   const levels = fallback.levels.map((level) => {
-    const existing = summary.levels.find((item) => item.level === level.level)
+    const existing = summaryLevels.find((item) => item.level === level.level)
     return existing ? { ...existing } : { ...level }
   })
 
@@ -76,6 +79,16 @@ const mapAuthorDetails = (author: AuthorDetailsResponse): AuthorDetails => ({
 })
 
 const CONTENT_AUTHORS_API_URL = `${GATEWAY_API_URL}/v1/content/authors`
+const FASTAPI_AUTHOR_SORT_FIELDS = new Set<AuthorSortField>(['fullName', 'updatedAt'])
+
+const canUseContentAuthorsApi = (params: {
+  city?: string
+  verified?: boolean
+  sortBy?: AuthorSortField
+}): boolean =>
+  !params.city?.trim() &&
+  params.verified === undefined &&
+  (!params.sortBy || FASTAPI_AUTHOR_SORT_FIELDS.has(params.sortBy))
 
 export const authorsService = {
   async fetchAuthors(
@@ -99,7 +112,8 @@ export const authorsService = {
         sortBy: params.sortBy,
         sortOrder: params.sortOrder,
       })
-      const url = query ? `${CONTENT_AUTHORS_API_URL}?${query}` : CONTENT_AUTHORS_API_URL
+      const baseUrl = canUseContentAuthorsApi(params) ? CONTENT_AUTHORS_API_URL : `${API_URL}/authors`
+      const url = query ? `${baseUrl}?${query}` : baseUrl
       const response = await createRequest(url)
 
       const data = await handleResponse<AuthorsListResponse>(

--- a/front/src/api/groups/groups.api.ts
+++ b/front/src/api/groups/groups.api.ts
@@ -1,5 +1,5 @@
 import toast from 'react-hot-toast'
-import { API_URL } from '@/api/common'
+import { API_URL, GATEWAY_API_URL } from '@/api/common'
 import { buildQueryString, createRequest, handleResponse } from '@/api/common'
 import type {
   IGroupResponse,
@@ -9,6 +9,8 @@ import type {
 } from '@/types/common'
 import type { SaveGroupDto } from '@/types/common'
 
+const CONTENT_GROUPS_API_URL = `${GATEWAY_API_URL}/v1/content/groups`
+
 export const groupsService = {
   async fetchGroups(params?: { page?: number; limit?: number }): Promise<IGroupsListResponse> {
     try {
@@ -16,7 +18,7 @@ export const groupsService = {
         page: params?.page,
         limit: params?.limit,
       })
-      const url = `${API_URL}/groups${query ? `?${query}` : ''}`
+      const url = `${CONTENT_GROUPS_API_URL}${query ? `?${query}` : ''}`
       const response = await createRequest(url)
 
       const data = await handleResponse<IGroupsListResponse>(response, 'Failed to fetch groups')

--- a/front/src/types/common/api.ts
+++ b/front/src/types/common/api.ts
@@ -546,7 +546,7 @@ export interface AuthorCardResponse {
   screenName: string | null
   profileUrl: string | null
   city: Record<string, unknown> | string | null
-  summary: PhotoAnalysisSummary
+  summary: PhotoAnalysisSummary | null
   photosCount: number | null
   audiosCount: number | null
   videosCount: number | null

--- a/services/api-gateway/app/modules/content/router.py
+++ b/services/api-gateway/app/modules/content/router.py
@@ -1,13 +1,36 @@
+from app.modules.content.service import (
+    ContentGatewayService,
+    get_content_gateway_service,
+)
 from fastapi import APIRouter, Depends, Request
-
-from app.modules.content.service import ContentGatewayService, get_content_gateway_service
 
 router = APIRouter(prefix="/api/v1/content", tags=["content"])
 
 
 @router.get("/groups")
-async def list_groups(request: Request, service: ContentGatewayService = Depends(get_content_gateway_service)):
-    return await service.forward(request, "GET", "/internal/content/groups", params=dict(request.query_params))
+async def list_groups(
+    request: Request,
+    service: ContentGatewayService = Depends(get_content_gateway_service),
+):
+    return await service.forward(
+        request,
+        "GET",
+        "/internal/content/groups",
+        params=dict(request.query_params),
+    )
+
+
+@router.get("/groups/search")
+async def search_groups(
+    request: Request,
+    service: ContentGatewayService = Depends(get_content_gateway_service),
+):
+    return await service.forward(
+        request,
+        "GET",
+        "/internal/content/groups/search",
+        params=dict(request.query_params),
+    )
 
 
 @router.get("/groups/{vk_group_id}")
@@ -20,8 +43,16 @@ async def get_group(
 
 
 @router.get("/posts")
-async def list_posts(request: Request, service: ContentGatewayService = Depends(get_content_gateway_service)):
-    return await service.forward(request, "GET", "/internal/content/posts", params=dict(request.query_params))
+async def list_posts(
+    request: Request,
+    service: ContentGatewayService = Depends(get_content_gateway_service),
+):
+    return await service.forward(
+        request,
+        "GET",
+        "/internal/content/posts",
+        params=dict(request.query_params),
+    )
 
 
 @router.get("/posts/{external_key}")
@@ -34,13 +65,29 @@ async def get_post(
 
 
 @router.get("/comments")
-async def list_comments(request: Request, service: ContentGatewayService = Depends(get_content_gateway_service)):
-    return await service.forward(request, "GET", "/internal/content/comments", params=dict(request.query_params))
+async def list_comments(
+    request: Request,
+    service: ContentGatewayService = Depends(get_content_gateway_service),
+):
+    return await service.forward(
+        request,
+        "GET",
+        "/internal/content/comments",
+        params=dict(request.query_params),
+    )
 
 
 @router.get("/authors")
-async def list_authors(request: Request, service: ContentGatewayService = Depends(get_content_gateway_service)):
-    return await service.forward(request, "GET", "/internal/content/authors", params=dict(request.query_params))
+async def list_authors(
+    request: Request,
+    service: ContentGatewayService = Depends(get_content_gateway_service),
+):
+    return await service.forward(
+        request,
+        "GET",
+        "/internal/content/authors",
+        params=dict(request.query_params),
+    )
 
 
 @router.get("/authors/{vk_author_id}")

--- a/services/api-gateway/tests/test_content_gateway.py
+++ b/services/api-gateway/tests/test_content_gateway.py
@@ -51,12 +51,52 @@ def app(fake_service):
 @pytest.mark.asyncio
 async def test_content_gateway_forwards_posts_query(app, fake_service):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        response = await client.get("/api/v1/content/posts?page=2", headers={"Authorization": "Bearer token"})
+        response = await client.get(
+            "/api/v1/content/posts?page=2",
+            headers={"Authorization": "Bearer token"},
+        )
 
     assert response.status_code == 200
     assert fake_service.calls[0]["method"] == "GET"
     assert fake_service.calls[0]["path"] == "/internal/content/posts"
     assert fake_service.calls[0]["params"] == {"page": "2"}
+
+
+@pytest.mark.asyncio
+async def test_content_gateway_forwards_authors_legacy_query(app, fake_service):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/api/v1/content/authors"
+            "?offset=24&limit=24&search=ada&verified=false"
+            "&sortBy=fullName&sortOrder=asc",
+            headers={"Authorization": "Bearer token"},
+        )
+
+    assert response.status_code == 200
+    assert fake_service.calls[0]["method"] == "GET"
+    assert fake_service.calls[0]["path"] == "/internal/content/authors"
+    assert fake_service.calls[0]["params"] == {
+        "offset": "24",
+        "limit": "24",
+        "search": "ada",
+        "verified": "false",
+        "sortBy": "fullName",
+        "sortOrder": "asc",
+    }
+
+
+@pytest.mark.asyncio
+async def test_content_gateway_forwards_groups_search(app, fake_service):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/api/v1/content/groups/search?q=alpha&limit=10",
+            headers={"Authorization": "Bearer token"},
+        )
+
+    assert response.status_code == 200
+    assert fake_service.calls[0]["method"] == "GET"
+    assert fake_service.calls[0]["path"] == "/internal/content/groups/search"
+    assert fake_service.calls[0]["params"] == {"q": "alpha", "limit": "10"}
 
 
 class FakeAuthService:
@@ -69,7 +109,16 @@ class FakeContentClient:
     def __init__(self):
         self.last_user_id = None
 
-    async def request(self, method, path, *, user_id, request_id=None, correlation_id=None, params=None):
+    async def request(
+        self,
+        method,
+        path,
+        *,
+        user_id,
+        request_id=None,
+        correlation_id=None,
+        params=None,
+    ):
         self.last_user_id = user_id
         return {"ok": True}
 

--- a/services/content-service/app/core/config.py
+++ b/services/content-service/app/core/config.py
@@ -10,6 +10,8 @@ class Settings(BaseSettings):
     kafka_bootstrap_servers: str = "kafka:9092"
     kafka_topic_vk: str = "parsevk.vk.events"
     kafka_consumer_enabled: bool = False
+    photo_analysis_base_url: str | None = None
+    photo_analysis_timeout_seconds: float = 1.5
 
 
 settings = Settings()

--- a/services/content-service/app/core/config.py
+++ b/services/content-service/app/core/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     kafka_consumer_enabled: bool = False
     photo_analysis_base_url: str | None = None
     photo_analysis_timeout_seconds: float = 1.5
+    photo_analysis_max_concurrency: int = 5
+    photo_analysis_enrichment_budget_seconds: float = 2.0
 
 
 settings = Settings()

--- a/services/content-service/app/modules/content/photo_analysis.py
+++ b/services/content-service/app/modules/content/photo_analysis.py
@@ -1,0 +1,39 @@
+import logging
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class PhotoAnalysisClient:
+    def __init__(self, base_url: str | None = None):
+        self.base_url = (base_url if base_url is not None else settings.photo_analysis_base_url)
+        self.timeout = settings.photo_analysis_timeout_seconds
+
+    async def summaries_by_vk_author_ids(
+        self,
+        vk_author_ids: list[int],
+    ) -> dict[int, dict[str, Any]]:
+        if not self.base_url or not vk_author_ids:
+            return {}
+
+        summaries: dict[int, dict[str, Any]] = {}
+        async with httpx.AsyncClient(
+            base_url=self.base_url.rstrip("/"),
+            timeout=httpx.Timeout(timeout=self.timeout, connect=min(self.timeout, 1.0)),
+        ) as client:
+            for vk_author_id in vk_author_ids:
+                try:
+                    response = await client.get(f"/photo-analysis/vk/{vk_author_id}/summary")
+                    response.raise_for_status()
+                    summaries[vk_author_id] = response.json()
+                except (httpx.HTTPError, ValueError) as exc:
+                    logger.warning(
+                        "Photo analysis summary unavailable for author %s: %s",
+                        vk_author_id,
+                        exc,
+                    )
+        return summaries

--- a/services/content-service/app/modules/content/photo_analysis.py
+++ b/services/content-service/app/modules/content/photo_analysis.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any
 
@@ -12,6 +13,8 @@ class PhotoAnalysisClient:
     def __init__(self, base_url: str | None = None):
         self.base_url = (base_url if base_url is not None else settings.photo_analysis_base_url)
         self.timeout = settings.photo_analysis_timeout_seconds
+        self.max_concurrency = max(settings.photo_analysis_max_concurrency, 1)
+        self.enrichment_budget_seconds = settings.photo_analysis_enrichment_budget_seconds
 
     async def summaries_by_vk_author_ids(
         self,
@@ -20,20 +23,31 @@ class PhotoAnalysisClient:
         if not self.base_url or not vk_author_ids:
             return {}
 
-        summaries: dict[int, dict[str, Any]] = {}
         async with httpx.AsyncClient(
             base_url=self.base_url.rstrip("/"),
             timeout=httpx.Timeout(timeout=self.timeout, connect=min(self.timeout, 1.0)),
         ) as client:
-            for vk_author_id in vk_author_ids:
+            semaphore = asyncio.Semaphore(self.max_concurrency)
+
+            async def fetch_summary(vk_author_id: int) -> tuple[int, dict[str, Any] | None]:
                 try:
-                    response = await client.get(f"/photo-analysis/vk/{vk_author_id}/summary")
-                    response.raise_for_status()
-                    summaries[vk_author_id] = response.json()
+                    async with semaphore:
+                        response = await client.get(f"/photo-analysis/vk/{vk_author_id}/summary")
+                        response.raise_for_status()
+                        return vk_author_id, response.json()
                 except (httpx.HTTPError, ValueError) as exc:
                     logger.warning(
                         "Photo analysis summary unavailable for author %s: %s",
                         vk_author_id,
                         exc,
                     )
+                    return vk_author_id, None
+
+            results = await asyncio.gather(
+                *(fetch_summary(vk_author_id) for vk_author_id in vk_author_ids)
+            )
+        summaries: dict[int, dict[str, Any]] = {}
+        for vk_author_id, summary in results:
+            if summary is not None:
+                summaries[vk_author_id] = summary
         return summaries

--- a/services/content-service/app/modules/content/repository.py
+++ b/services/content-service/app/modules/content/repository.py
@@ -245,9 +245,9 @@ class ContentRepository:
         fields = {
             "fullName": ContentAuthor.display_name,
             "updatedAt": ContentAuthor.updated_at,
-            "city": ContentAuthor.display_name,
-            "verifiedAt": ContentAuthor.updated_at,
         }
+        if sort_by and sort_by not in fields:
+            raise ValueError(f"Unsupported author sort field: {sort_by}")
         field = fields.get(sort_by or "updatedAt", ContentAuthor.updated_at)
         primary = (
             field.asc().nulls_last()

--- a/services/content-service/app/modules/content/repository.py
+++ b/services/content-service/app/modules/content/repository.py
@@ -1,6 +1,6 @@
 from math import ceil
 
-from sqlalchemy import Select, func, select
+from sqlalchemy import Select, String, and_, cast, false, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import ContentAuthor, ContentComment, ContentGroup, ContentPost
@@ -11,13 +11,47 @@ class ContentRepository:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def list_groups(self, page: int, limit: int) -> dict:
-        rows, total = await self._paginate(select(ContentGroup), page, limit, ContentGroup.id.desc())
+    async def list_groups(
+        self,
+        page: int,
+        limit: int,
+        search: str | None = None,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
+    ) -> dict:
+        stmt = select(ContentGroup)
+        if search:
+            pattern = f"%{search.lower()}%"
+            stmt = stmt.where(
+                or_(
+                    func.lower(ContentGroup.name).like(pattern),
+                    func.lower(ContentGroup.screen_name).like(pattern),
+                    cast(ContentGroup.vk_group_id, String).like(pattern),
+                )
+            )
+        rows, total = await self._paginate(
+            stmt,
+            page,
+            limit,
+            *self._group_order(sort_by, sort_order),
+        )
         return self._page([self.group_to_dict(row) for row in rows], total, page, limit)
 
     async def get_group(self, vk_group_id: int) -> dict | None:
-        row = await self.session.scalar(select(ContentGroup).where(ContentGroup.vk_group_id == vk_group_id))
+        row = await self.session.scalar(
+            select(ContentGroup).where(ContentGroup.vk_group_id == vk_group_id)
+        )
         return self.group_to_dict(row) if row else None
+
+    async def search_groups(self, query: str, limit: int) -> dict:
+        page = await self.list_groups(
+            page=1,
+            limit=limit,
+            search=query,
+            sort_by="name",
+            sort_order="asc",
+        )
+        return {"items": page["items"], "total": page["total"], "query": query}
 
     async def list_posts(self, page: int, limit: int) -> dict:
         rows, total = await self._paginate(
@@ -30,7 +64,9 @@ class ContentRepository:
         return self._page([self.post_to_dict(row) for row in rows], total, page, limit)
 
     async def get_post(self, external_key: str) -> dict | None:
-        row = await self.session.scalar(select(ContentPost).where(ContentPost.external_key == external_key))
+        row = await self.session.scalar(
+            select(ContentPost).where(ContentPost.external_key == external_key)
+        )
         return self.post_to_dict(row) if row else None
 
     async def list_comments(self, page: int, limit: int) -> dict:
@@ -43,50 +79,188 @@ class ContentRepository:
         )
         return self._page([self.comment_to_dict(row) for row in rows], total, page, limit)
 
-    async def list_authors(self, page: int, limit: int) -> dict:
-        rows, total = await self._paginate(select(ContentAuthor), page, limit, ContentAuthor.id.desc())
-        return self._page([self.author_to_dict(row) for row in rows], total, page, limit)
+    async def list_authors(
+        self,
+        offset: int = 0,
+        limit: int = 20,
+        search: str | None = None,
+        city: str | None = None,
+        verified: bool | None = None,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
+    ) -> dict:
+        stmt = select(ContentAuthor)
+        conditions = []
+        if search:
+            pattern = f"%{search.lower()}%"
+            conditions.append(
+                or_(
+                    func.lower(ContentAuthor.display_name).like(pattern),
+                    cast(ContentAuthor.vk_author_id, String).like(pattern),
+                )
+            )
+        if city:
+            conditions.append(false())
+        if verified is True:
+            conditions.append(false())
+        if conditions:
+            stmt = stmt.where(and_(*conditions))
+
+        rows, total = await self._offset_paginate(
+            stmt,
+            offset,
+            limit,
+            *self._author_order(sort_by, sort_order),
+        )
+        return {
+            "items": [self.author_to_dict(row) for row in rows],
+            "total": total,
+            "hasMore": offset + limit < total,
+        }
 
     async def get_author(self, vk_author_id: int) -> dict | None:
-        row = await self.session.scalar(select(ContentAuthor).where(ContentAuthor.vk_author_id == vk_author_id))
+        row = await self.session.scalar(
+            select(ContentAuthor).where(ContentAuthor.vk_author_id == vk_author_id)
+        )
         return self.author_to_dict(row) if row else None
 
     async def list_authors_bulk(self, vk_author_ids: list[int]) -> list[dict]:
-        rows = await self.session.scalars(select(ContentAuthor).where(ContentAuthor.vk_author_id.in_(vk_author_ids)))
+        rows = await self.session.scalars(
+            select(ContentAuthor).where(ContentAuthor.vk_author_id.in_(vk_author_ids))
+        )
         return [self.author_to_dict(row) for row in rows]
 
     async def list_posts_bulk(self, external_keys: list[str]) -> list[dict]:
-        rows = await self.session.scalars(select(ContentPost).where(ContentPost.external_key.in_(external_keys)))
+        rows = await self.session.scalars(
+            select(ContentPost).where(ContentPost.external_key.in_(external_keys))
+        )
         return [self.post_to_dict(row) for row in rows]
 
     async def _paginate(self, stmt: Select, page: int, limit: int, *order_by) -> tuple[list, int]:
         offset = (page - 1) * limit
+        return await self._offset_paginate(stmt, offset, limit, *order_by)
+
+    async def _offset_paginate(
+        self,
+        stmt: Select,
+        offset: int,
+        limit: int,
+        *order_by,
+    ) -> tuple[list, int]:
         total = await self.session.scalar(select(func.count()).select_from(stmt.subquery()))
         result = await self.session.scalars(stmt.order_by(*order_by).offset(offset).limit(limit))
         return list(result), int(total or 0)
 
     def _page(self, items: list[dict], total: int, page: int, limit: int) -> dict:
         total_pages = ceil(total / limit) if total else 0
-        return {"items": items, "total": total, "page": page, "limit": limit, "totalPages": total_pages, "hasMore": page < total_pages}
+        return {
+            "items": items,
+            "total": total,
+            "page": page,
+            "limit": limit,
+            "totalPages": total_pages,
+            "hasMore": page < total_pages,
+        }
 
     def group_to_dict(self, row: ContentGroup) -> dict:
         return {
             "id": row.id,
+            "vkId": row.vk_group_id,
             "vkGroupId": row.vk_group_id,
             "screenName": row.screen_name,
             "name": row.name,
+            "isClosed": None,
+            "deactivated": None,
+            "type": None,
+            "photo50": None,
+            "photo100": None,
+            "photo200": None,
+            "activity": None,
+            "ageLimits": None,
+            "description": None,
+            "membersCount": None,
+            "status": None,
+            "verified": None,
+            "wall": None,
+            "addresses": None,
+            "city": None,
+            "counters": None,
+            "createdAt": dt(row.updated_at),
             "lastCollectedAt": dt(row.last_collected_at),
             "updatedAt": dt(row.updated_at),
         }
 
     def author_to_dict(self, row: ContentAuthor) -> dict:
+        display_name = row.display_name.strip() if row.display_name else f"VK {row.vk_author_id}"
+        first_name, last_name = self._split_display_name(display_name)
         return {
             "id": row.id,
             "vkAuthorId": row.vk_author_id,
+            "vkUserId": row.vk_author_id,
             "type": row.type,
             "displayName": row.display_name,
+            "firstName": first_name,
+            "lastName": last_name,
+            "fullName": display_name,
+            "photo50": None,
+            "photo100": None,
+            "photo200": None,
+            "domain": None,
+            "screenName": None,
+            "profileUrl": f"https://vk.com/id{row.vk_author_id}",
+            "city": None,
+            "country": None,
+            "summary": None,
+            "photosCount": None,
+            "audiosCount": None,
+            "videosCount": None,
+            "friendsCount": None,
+            "followersCount": None,
+            "lastSeenAt": None,
+            "verifiedAt": None,
+            "isVerified": False,
+            "createdAt": dt(row.updated_at),
             "updatedAt": dt(row.updated_at),
         }
+
+    def _group_order(self, sort_by: str | None, sort_order: str):
+        direction = sort_order if sort_order in {"asc", "desc"} else "desc"
+        fields = {
+            "name": ContentGroup.name,
+            "screenName": ContentGroup.screen_name,
+            "updatedAt": ContentGroup.updated_at,
+            "vkId": ContentGroup.vk_group_id,
+            "vkGroupId": ContentGroup.vk_group_id,
+        }
+        field = fields.get(sort_by or "updatedAt", ContentGroup.updated_at)
+        primary = (
+            field.asc().nulls_last()
+            if direction == "asc"
+            else field.desc().nulls_last()
+        )
+        return primary, ContentGroup.id.desc()
+
+    def _author_order(self, sort_by: str | None, sort_order: str):
+        direction = sort_order if sort_order in {"asc", "desc"} else "desc"
+        fields = {
+            "fullName": ContentAuthor.display_name,
+            "updatedAt": ContentAuthor.updated_at,
+            "city": ContentAuthor.display_name,
+            "verifiedAt": ContentAuthor.updated_at,
+        }
+        field = fields.get(sort_by or "updatedAt", ContentAuthor.updated_at)
+        primary = (
+            field.asc().nulls_last()
+            if direction == "asc"
+            else field.desc().nulls_last()
+        )
+        return primary, ContentAuthor.id.desc()
+
+    def _split_display_name(self, display_name: str) -> tuple[str, str]:
+        parts = display_name.split()
+        if not parts:
+            return "", ""
+        return parts[0], " ".join(parts[1:])
 
     def post_to_dict(self, row: ContentPost) -> dict:
         return {

--- a/services/content-service/app/modules/content/router.py
+++ b/services/content-service/app/modules/content/router.py
@@ -1,9 +1,15 @@
+import logging
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import require_internal_token
 from app.db.session import get_session
+from app.modules.content.photo_analysis import PhotoAnalysisClient
 from app.modules.content.repository import ContentRepository
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/internal/content",
@@ -16,17 +22,42 @@ async def get_content_repository(session: AsyncSession = Depends(get_session)) -
     return ContentRepository(session)
 
 
+async def get_photo_analysis_client() -> PhotoAnalysisClient:
+    return PhotoAnalysisClient()
+
+
 @router.get("/groups")
 async def list_groups(
     page: int = Query(default=1, ge=1),
+    limit: int = Query(default=50, ge=1, le=200),
+    search: str | None = Query(default=None),
+    sort_by: str | None = Query(default=None, alias="sortBy"),
+    sort_order: str = Query(default="desc", alias="sortOrder"),
+    repository: ContentRepository = Depends(get_content_repository),
+):
+    return await repository.list_groups(
+        page=page,
+        limit=limit,
+        search=normalize_text(search),
+        sort_by=sort_by,
+        sort_order=normalize_sort_order(sort_order),
+    )
+
+
+@router.get("/groups/search")
+async def search_groups(
+    q: str = Query(min_length=1),
     limit: int = Query(default=20, ge=1, le=100),
     repository: ContentRepository = Depends(get_content_repository),
 ):
-    return await repository.list_groups(page, limit)
+    return await repository.search_groups(normalize_text(q) or q, limit)
 
 
 @router.get("/groups/{vk_group_id}")
-async def get_group(vk_group_id: int, repository: ContentRepository = Depends(get_content_repository)):
+async def get_group(
+    vk_group_id: int,
+    repository: ContentRepository = Depends(get_content_repository),
+):
     row = await repository.get_group(vk_group_id)
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Group not found")
@@ -43,7 +74,10 @@ async def list_posts(
 
 
 @router.get("/posts/{external_key}")
-async def get_post(external_key: str, repository: ContentRepository = Depends(get_content_repository)):
+async def get_post(
+    external_key: str,
+    repository: ContentRepository = Depends(get_content_repository),
+):
     row = await repository.get_post(external_key)
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Post not found")
@@ -61,18 +95,41 @@ async def list_comments(
 
 @router.get("/authors")
 async def list_authors(
-    page: int = Query(default=1, ge=1),
     limit: int = Query(default=20, ge=1, le=100),
+    page: int | None = Query(default=None, ge=1),
+    offset: int | None = Query(default=None, ge=0),
+    search: str | None = Query(default=None),
+    city: str | None = Query(default=None),
+    verified: str | None = Query(default=None),
+    sort_by: str | None = Query(default=None, alias="sortBy"),
+    sort_order: str = Query(default="desc", alias="sortOrder"),
     repository: ContentRepository = Depends(get_content_repository),
+    photo_analysis_client: PhotoAnalysisClient = Depends(get_photo_analysis_client),
 ):
-    return await repository.list_authors(page, limit)
+    resolved_offset = offset if offset is not None else ((page or 1) - 1) * limit
+    payload = await repository.list_authors(
+        offset=resolved_offset,
+        limit=limit,
+        search=normalize_text(search),
+        city=normalize_text(city),
+        verified=parse_optional_bool(verified),
+        sort_by=sort_by,
+        sort_order=normalize_sort_order(sort_order),
+    )
+    await enrich_author_summaries(payload["items"], photo_analysis_client)
+    return payload
 
 
 @router.get("/authors/{vk_author_id}")
-async def get_author(vk_author_id: int, repository: ContentRepository = Depends(get_content_repository)):
+async def get_author(
+    vk_author_id: int,
+    repository: ContentRepository = Depends(get_content_repository),
+    photo_analysis_client: PhotoAnalysisClient = Depends(get_photo_analysis_client),
+):
     row = await repository.get_author(vk_author_id)
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Author not found")
+    await enrich_author_summaries([row], photo_analysis_client)
     return row
 
 
@@ -90,3 +147,49 @@ async def list_posts_bulk(
     repository: ContentRepository = Depends(get_content_repository),
 ):
     return await repository.list_posts_bulk(external_keys)
+
+
+def normalize_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def normalize_sort_order(value: str | None) -> str:
+    return value if value in {"asc", "desc"} else "desc"
+
+
+def parse_optional_bool(value: Any) -> bool | None:
+    if value in {None, "", "all"}:
+        return None
+    if value in {True, "true", "1"}:
+        return True
+    if value in {False, "false", "0"}:
+        return False
+    return None
+
+
+async def enrich_author_summaries(
+    items: list[dict],
+    photo_analysis_client: PhotoAnalysisClient,
+) -> None:
+    vk_author_ids = [
+        int(item["vkUserId"])
+        for item in items
+        if item.get("vkUserId") is not None
+    ]
+    if not vk_author_ids:
+        return
+
+    try:
+        summaries = await photo_analysis_client.summaries_by_vk_author_ids(vk_author_ids)
+    except Exception as exc:
+        logger.warning("Photo analysis enrichment failed: %s", exc)
+        return
+
+    for item in items:
+        summary = summaries.get(int(item["vkUserId"]))
+        if summary is not None:
+            item["summary"] = summary
+            item["photosCount"] = summary.get("total", item.get("photosCount"))

--- a/services/content-service/app/modules/content/router.py
+++ b/services/content-service/app/modules/content/router.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any
 
@@ -10,6 +11,7 @@ from app.modules.content.photo_analysis import PhotoAnalysisClient
 from app.modules.content.repository import ContentRepository
 
 logger = logging.getLogger(__name__)
+SUPPORTED_AUTHOR_SORT_FIELDS = {"fullName", "updatedAt"}
 
 router = APIRouter(
     prefix="/internal/content",
@@ -106,6 +108,7 @@ async def list_authors(
     repository: ContentRepository = Depends(get_content_repository),
     photo_analysis_client: PhotoAnalysisClient = Depends(get_photo_analysis_client),
 ):
+    validate_author_query_params(city=city, verified=verified, sort_by=sort_by)
     resolved_offset = offset if offset is not None else ((page or 1) - 1) * limit
     payload = await repository.list_authors(
         offset=resolved_offset,
@@ -170,6 +173,29 @@ def parse_optional_bool(value: Any) -> bool | None:
     return None
 
 
+def validate_author_query_params(
+    *,
+    city: str | None,
+    verified: str | None,
+    sort_by: str | None,
+) -> None:
+    if normalize_text(city) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Author city filter is not supported by the content projection",
+        )
+    if verified not in {None, "", "all"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Author verified filter is not supported by the content projection",
+        )
+    if sort_by and sort_by not in SUPPORTED_AUTHOR_SORT_FIELDS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported author sort field: {sort_by}",
+        )
+
+
 async def enrich_author_summaries(
     items: list[dict],
     photo_analysis_client: PhotoAnalysisClient,
@@ -183,7 +209,10 @@ async def enrich_author_summaries(
         return
 
     try:
-        summaries = await photo_analysis_client.summaries_by_vk_author_ids(vk_author_ids)
+        summaries = await asyncio.wait_for(
+            photo_analysis_client.summaries_by_vk_author_ids(vk_author_ids),
+            timeout=getattr(photo_analysis_client, "enrichment_budget_seconds", 2.0),
+        )
     except Exception as exc:
         logger.warning("Photo analysis enrichment failed: %s", exc)
         return

--- a/services/content-service/tests/test_content_api.py
+++ b/services/content-service/tests/test_content_api.py
@@ -10,7 +10,7 @@ from _service_path import use_service_path
 use_service_path()
 
 from app.main import create_app
-from app.modules.content.router import get_content_repository
+from app.modules.content.router import get_content_repository, get_photo_analysis_client
 
 
 @pytest.fixture
@@ -19,36 +19,187 @@ def anyio_backend():
 
 
 class FakeRepository:
+    def __init__(self):
+        self.calls = []
+        self.authors = [
+            self.author(1, 101, "Ada Lovelace", "2026-05-01T00:00:00+00:00"),
+            self.author(2, 202, "Grace Hopper", "2026-05-02T00:00:00+00:00"),
+        ]
+        self.groups = [
+            self.group(1, 10, "Alpha Group", "alpha", "2026-05-01T00:00:00+00:00"),
+            self.group(2, 20, "Beta Group", "beta", "2026-05-02T00:00:00+00:00"),
+        ]
+
     async def list_posts(self, page, limit):
-        return {"items": [{"externalKey": "-1:2"}], "total": 1, "page": page, "limit": limit, "totalPages": 1, "hasMore": False}
+        return {
+            "items": [{"externalKey": "-1:2"}],
+            "total": 1,
+            "page": page,
+            "limit": limit,
+            "totalPages": 1,
+            "hasMore": False,
+        }
 
     async def get_post(self, external_key):
         return {"externalKey": external_key}
 
-    async def list_groups(self, page, limit):
-        return {"items": [], "total": 0, "page": page, "limit": limit, "totalPages": 0, "hasMore": False}
+    async def list_groups(self, page, limit, search=None, sort_by=None, sort_order="desc"):
+        self.calls.append(("list_groups", page, limit, search, sort_by, sort_order))
+        items = [
+            item
+            for item in self.groups
+            if not search or search.lower() in item["name"].lower()
+        ]
+        reverse = sort_order != "asc"
+        if sort_by == "name":
+            items = sorted(items, key=lambda item: item["name"], reverse=reverse)
+        return {
+            "items": items[(page - 1) * limit : page * limit],
+            "total": len(items),
+            "page": page,
+            "limit": limit,
+            "totalPages": 1 if items else 0,
+            "hasMore": False,
+        }
 
     async def get_group(self, vk_group_id):
-        return {"vkGroupId": vk_group_id}
+        return next((item for item in self.groups if item["vkId"] == vk_group_id), None)
+
+    async def search_groups(self, query, limit):
+        self.calls.append(("search_groups", query, limit))
+        items = [
+            item
+            for item in self.groups
+            if query.lower() in item["name"].lower()
+        ][:limit]
+        return {"items": items, "total": len(items), "query": query}
 
     async def list_comments(self, page, limit):
-        return {"items": [], "total": 0, "page": page, "limit": limit, "totalPages": 0, "hasMore": False}
+        return {
+            "items": [],
+            "total": 0,
+            "page": page,
+            "limit": limit,
+            "totalPages": 0,
+            "hasMore": False,
+        }
 
-    async def list_authors(self, page, limit):
-        return {"items": [], "total": 0, "page": page, "limit": limit, "totalPages": 0, "hasMore": False}
+    async def list_authors(
+        self,
+        offset=0,
+        limit=20,
+        search=None,
+        city=None,
+        verified=None,
+        sort_by=None,
+        sort_order="desc",
+    ):
+        self.calls.append(
+            ("list_authors", offset, limit, search, city, verified, sort_by, sort_order)
+        )
+        items = [
+            item
+            for item in self.authors
+            if not search or search.lower() in item["displayName"].lower()
+        ]
+        reverse = sort_order != "asc"
+        if sort_by == "fullName":
+            items = sorted(items, key=lambda item: item["displayName"], reverse=reverse)
+        if verified is True or city:
+            items = []
+        return {
+            "items": items[offset : offset + limit],
+            "total": len(items),
+            "hasMore": offset + limit < len(items),
+        }
 
     async def get_author(self, vk_author_id):
-        return {"vkAuthorId": vk_author_id}
+        return next((item for item in self.authors if item["vkAuthorId"] == vk_author_id), None)
+
+    def author(self, id, vk_author_id, full_name, updated_at):
+        first_name, *last_name = full_name.split()
+        return {
+            "id": id,
+            "vkAuthorId": vk_author_id,
+            "vkUserId": vk_author_id,
+            "type": "user",
+            "displayName": full_name,
+            "firstName": first_name,
+            "lastName": " ".join(last_name),
+            "fullName": full_name,
+            "photo50": None,
+            "photo100": None,
+            "photo200": None,
+            "domain": None,
+            "screenName": None,
+            "profileUrl": f"https://vk.com/id{vk_author_id}",
+            "city": None,
+            "country": None,
+            "summary": None,
+            "photosCount": None,
+            "audiosCount": None,
+            "videosCount": None,
+            "friendsCount": None,
+            "followersCount": None,
+            "lastSeenAt": None,
+            "verifiedAt": None,
+            "isVerified": False,
+            "createdAt": updated_at,
+            "updatedAt": updated_at,
+        }
+
+    def group(self, id, vk_id, name, screen_name, updated_at):
+        return {
+            "id": id,
+            "vkId": vk_id,
+            "name": name,
+            "screenName": screen_name,
+            "updatedAt": updated_at,
+        }
+
+
+class FakePhotoAnalysisClient:
+    def __init__(self, *, fail=False):
+        self.fail = fail
+        self.calls = []
+
+    async def summaries_by_vk_author_ids(self, vk_author_ids):
+        self.calls.append(vk_author_ids)
+        if self.fail:
+            raise RuntimeError("analysis unavailable")
+        return {
+            101: {
+                "total": 3,
+                "suspicious": 1,
+                "lastAnalyzedAt": "2026-05-03T00:00:00+00:00",
+                "categories": [],
+                "levels": [],
+            }
+        }
 
 
 @pytest.fixture
-def app():
+def repository():
+    return FakeRepository()
+
+
+@pytest.fixture
+def photo_analysis_client():
+    return FakePhotoAnalysisClient()
+
+
+@pytest.fixture
+def app(repository, photo_analysis_client):
     app = create_app()
 
-    async def repository():
-        return FakeRepository()
+    async def repository_override():
+        return repository
 
-    app.dependency_overrides[get_content_repository] = repository
+    async def photo_analysis_client_override():
+        return photo_analysis_client
+
+    app.dependency_overrides[get_content_repository] = repository_override
+    app.dependency_overrides[get_photo_analysis_client] = photo_analysis_client_override
     return app
 
 
@@ -75,3 +226,105 @@ async def test_content_posts_pagination_and_detail(app):
     assert listed.json()["limit"] == 10
     assert detail.status_code == 200
     assert detail.json() == {"externalKey": "-1:2"}
+
+
+@pytest.mark.anyio
+async def test_authors_list_supports_legacy_filters_sort_and_offset_pagination(
+    app,
+    repository,
+    photo_analysis_client,
+):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/internal/content/authors?offset=0&limit=1&search=ada&sortBy=fullName&sortOrder=asc&verified=false",
+            headers=headers(),
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["hasMore"] is False
+    assert payload["items"][0]["vkUserId"] == 101
+    assert payload["items"][0]["fullName"] == "Ada Lovelace"
+    assert payload["items"][0]["summary"]["total"] == 3
+    assert repository.calls[0] == (
+        "list_authors",
+        0,
+        1,
+        "ada",
+        None,
+        False,
+        "fullName",
+        "asc",
+    )
+    assert photo_analysis_client.calls == [[101]]
+
+
+@pytest.mark.anyio
+async def test_authors_empty_state_keeps_legacy_shape(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/internal/content/authors?search=missing", headers=headers())
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "total": 0, "hasMore": False}
+
+
+@pytest.mark.anyio
+async def test_author_detail_success_and_not_found(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        found = await client.get("/internal/content/authors/101", headers=headers())
+        missing = await client.get("/internal/content/authors/999", headers=headers())
+
+    assert found.status_code == 200
+    assert found.json()["vkUserId"] == 101
+    assert found.json()["summary"]["total"] == 3
+    assert missing.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_author_photo_analysis_failure_does_not_fail_response(repository):
+    app = create_app()
+
+    async def repository_override():
+        return repository
+
+    async def photo_analysis_client_override():
+        return FakePhotoAnalysisClient(fail=True)
+
+    app.dependency_overrides[get_content_repository] = repository_override
+    app.dependency_overrides[get_photo_analysis_client] = photo_analysis_client_override
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/internal/content/authors?limit=1", headers=headers())
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["summary"] is None
+
+
+@pytest.mark.anyio
+async def test_groups_list_supports_search_sort_and_pagination(app, repository):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/internal/content/groups?page=1&limit=1&search=beta&sortBy=name&sortOrder=asc",
+            headers=headers(),
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["vkId"] == 20
+    assert repository.calls[0] == ("list_groups", 1, 1, "beta", "name", "asc")
+
+
+@pytest.mark.anyio
+async def test_groups_empty_search_and_detail_not_found(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        listed = await client.get("/internal/content/groups?search=missing", headers=headers())
+        searched = await client.get("/internal/content/groups/search?q=alpha", headers=headers())
+        missing = await client.get("/internal/content/groups/999", headers=headers())
+
+    assert listed.status_code == 200
+    assert listed.json()["items"] == []
+    assert searched.status_code == 200
+    assert searched.json()["items"][0]["vkId"] == 10
+    assert missing.status_code == 404

--- a/services/content-service/tests/test_content_api.py
+++ b/services/content-service/tests/test_content_api.py
@@ -1,4 +1,5 @@
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -159,12 +160,18 @@ class FakeRepository:
 
 
 class FakePhotoAnalysisClient:
-    def __init__(self, *, fail=False):
+    def __init__(self, *, fail=False, delay_seconds=0, enrichment_budget_seconds=2.0):
         self.fail = fail
+        self.delay_seconds = delay_seconds
+        self.enrichment_budget_seconds = enrichment_budget_seconds
         self.calls = []
 
     async def summaries_by_vk_author_ids(self, vk_author_ids):
         self.calls.append(vk_author_ids)
+        if self.delay_seconds:
+            import anyio
+
+            await anyio.sleep(self.delay_seconds)
         if self.fail:
             raise RuntimeError("analysis unavailable")
         return {
@@ -236,7 +243,7 @@ async def test_authors_list_supports_legacy_filters_sort_and_offset_pagination(
 ):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get(
-            "/internal/content/authors?offset=0&limit=1&search=ada&sortBy=fullName&sortOrder=asc&verified=false",
+            "/internal/content/authors?offset=0&limit=1&search=ada&sortBy=fullName&sortOrder=asc",
             headers=headers(),
         )
 
@@ -253,11 +260,28 @@ async def test_authors_list_supports_legacy_filters_sort_and_offset_pagination(
         1,
         "ada",
         None,
-        False,
+        None,
         "fullName",
         "asc",
     )
     assert photo_analysis_client.calls == [[101]]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "query",
+    [
+        "sortBy=photosCount",
+        "city=Yakutsk",
+        "verified=true",
+        "verified=false",
+    ],
+)
+async def test_authors_reject_projection_limited_query_params(app, query):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(f"/internal/content/authors?{query}", headers=headers())
+
+    assert response.status_code == 400
 
 
 @pytest.mark.anyio
@@ -267,6 +291,27 @@ async def test_authors_empty_state_keeps_legacy_shape(app):
 
     assert response.status_code == 200
     assert response.json() == {"items": [], "total": 0, "hasMore": False}
+
+
+@pytest.mark.anyio
+async def test_authors_accept_updated_at_sort(app, repository):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/internal/content/authors?sortBy=updatedAt&sortOrder=desc",
+            headers=headers(),
+        )
+
+    assert response.status_code == 200
+    assert repository.calls[0] == (
+        "list_authors",
+        0,
+        20,
+        None,
+        None,
+        None,
+        "updatedAt",
+        "desc",
+    )
 
 
 @pytest.mark.anyio
@@ -299,6 +344,32 @@ async def test_author_photo_analysis_failure_does_not_fail_response(repository):
 
     assert response.status_code == 200
     assert response.json()["items"][0]["summary"] is None
+
+
+@pytest.mark.anyio
+async def test_author_photo_analysis_slow_client_uses_global_budget(repository):
+    app = create_app()
+
+    async def repository_override():
+        return repository
+
+    async def photo_analysis_client_override():
+        return FakePhotoAnalysisClient(delay_seconds=0.2, enrichment_budget_seconds=0.05)
+
+    app.dependency_overrides[get_content_repository] = repository_override
+    app.dependency_overrides[get_photo_analysis_client] = photo_analysis_client_override
+
+    started = time.perf_counter()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(
+            "/internal/content/authors?limit=2",
+            headers=headers(),
+        )
+    elapsed = time.perf_counter() - started
+
+    assert response.status_code == 200
+    assert elapsed < 0.15
+    assert [item["summary"] for item in response.json()["items"]] == [None, None]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #148

## Summary
- Migrated FastAPI content-service authors read contract for list/details, search, supported sorting and offset pagination.
- Added bounded, best-effort authors photo-analysis summary enrichment behind optional `CONTENT_PHOTO_ANALYSIS_BASE_URL`; enrichment uses bounded concurrency plus a global budget and failures return the base authors response with nullable summary.
- Migrated FastAPI content-service groups read/search contract for list/detail/search, filters, sorting and page pagination.
- Updated API gateway content routes and frontend authors/groups read clients to use FastAPI/gateway paths where projection parity is supported.
- Added parity map in `docs/FASTAPI_MIG_004_AUTHORS_GROUPS_PARITY.md`.

## Projection-limited author reads
- FastAPI authors supports `search`, `offset`, `limit`, `page`, `sortBy=fullName`, `sortBy=updatedAt`, and `sortOrder`.
- Direct FastAPI calls with `city`, `verified`, or unsupported `sortBy` now return HTTP 400 instead of silently returning semantically wrong data.
- Frontend falls back to legacy `API_URL /authors` for `city`, any `verified` filter, and unsupported sort fields: `photosCount`, `audiosCount`, `videosCount`, `friendsCount`, `followersCount`, `lastSeenAt`, `verifiedAt`.

## Follow-ups
- [ ] `POST /authors/refresh`: requires authors saver/VK refresh dependency outside content-service.
- [ ] `DELETE /authors/:vkUserId`: legacy deletes Author plus related comments; content projection is read-model only.
- [ ] `PATCH /authors/:vkUserId/verify`: `verifiedAt` is not projected into content-service yet.
- [ ] Richer author projection for city, verifiedAt, counters, followers and lastSeen parity.
- [ ] `POST /groups/save`, `POST /groups/upload`: require VK API write/upsert dependency and bulk throttling behavior.
- [ ] `DELETE /groups/:id`, `DELETE /groups/all`: destructive write operations remain on NestJS.
- [ ] `GET /groups/search/region`: depends on VK region search implementation and remains on NestJS.

## Tests
- [x] `uv run --extra test pytest tests/test_content_api.py` from `services/content-service`
- [x] `uv run --extra test pytest tests/test_content_gateway.py` from `services/api-gateway`
- [x] `npm test -- src/api/authors/authors.api.test.ts` from `front`
- [x] `npm run typecheck` from `front`
- [x] `uv run --with ruff ruff check app/modules/content/photo_analysis.py app/modules/content/repository.py app/modules/content/router.py tests/test_content_api.py --ignore B008,E402,S105` from `services/content-service`
- [x] `uv run --with ruff ruff check app/modules/content/router.py tests/test_content_gateway.py --ignore B008,E402,S105` from `services/api-gateway`