### PR TITLE
feat(parsevkctl): implement PR check-status merge guard

### DIFF
--- a/docs/PARSEVKCTL.md
+++ b/docs/PARSEVKCTL.md
@@ -18,6 +18,21 @@ When commands are run from `tools/parsevkctl-go`, the CLI also discovers the
 local `config.json` in that directory. You can override discovery with
 `--config <path>`.
 
+Merge check enforcement is controlled by:
+
+```json
+"merge": {
+  "requireChecks": true
+}
+```
+
+When `merge.requireChecks` is `true`, `task merge` loads the linked pull
+request checks through GitHub CLI and allows merge only when at least one check
+exists and all checks are successful, skipped, or neutral. Missing checks,
+pending checks, failed checks, and unknown check states block the merge with an
+actionable error that names the affected checks. When `merge.requireChecks` is
+`false`, `task merge` does not enforce PR checks.
+
 ## Direct Go Invocation
 
 ```powershell
@@ -122,6 +137,12 @@ merged yet.
 GitHub CLI when `merge.deleteBranch` is `true`. If the command is run from the
 PR head branch, it switches back to the configured default branch, pulls with
 `--ff-only`, and deletes the local task branch with `git branch -d`.
+
+If `merge.requireChecks` is `true`, `task merge` checks the linked PR before
+building the merge plan. It blocks PRs with no checks, pending checks, failed
+checks, or unknown check states. Successful, skipped, and neutral checks are
+accepted. The project config currently keeps `merge.requireChecks` set to
+`false`; enabling it should be a separate rollout after CI is stable.
 
 Protected branches such as `main`, `master`, and
 `fastapi-microservices-rewrite` are never deleted by the Git adapter.

--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -59,6 +59,10 @@ boundary for issues, pull requests and project status operations, and currently
 shells out to `gh` behind that boundary while returning `internal/domain`
 types.
 
+The adapter also reads pull request check status for `task merge` when
+`merge.requireChecks` is enabled. It prefers `gh pr checks <number> --json`
+and falls back to conservative text parsing when JSON output is unavailable.
+
 ## Branch naming
 
 Task branches use this format:
@@ -142,6 +146,23 @@ default branch when safe, and pulls with `--ff-only`. When
 `merge.deleteBranch` is `true`, the merge operation asks GitHub to delete the
 remote PR branch and the local task branch is deleted with `git branch -d` when
 the command was run from that branch.
+
+`merge.requireChecks` controls PR check enforcement:
+
+```json
+"merge": {
+  "requireChecks": true
+}
+```
+
+- `true`: `task merge` requires the linked PR to have at least one check and
+  allows merge only when all checks are successful, skipped, or neutral.
+- `false`: `task merge` does not enforce check status.
+
+With `true`, missing checks, pending checks, failed checks, and unknown check
+states block merge with an error that names the affected checks. The default
+project config still uses `false`; enabling required checks belongs in a
+separate rollout.
 
 Use `--dry-run` with any write command to render the operation plan without
 executing it:

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -447,6 +447,146 @@ func TestTaskMergeDryRunPlan(t *testing.T) {
 	deps.assertNoWrites(t)
 }
 
+func TestTaskMergeRequireChecksAllowsGreenChecks(t *testing.T) {
+	deps := okDeps()
+	requireChecks := true
+	deps.Config.Merge.RequireChecks = &requireChecks
+	deps.GitHub.prs = []domain.PullRequest{{
+		Number: 9,
+		State:  domain.PullRequestStateOpen,
+		Base:   "fastapi-microservices-rewrite",
+		Head:   "feat/issue-112-add-read-only-task-commands",
+	}}
+	deps.GitHub.checks = domain.PullRequestChecks{
+		PullRequestNumber: 9,
+		Total:             2,
+		Successful:        2,
+		Checks: []domain.PullRequestCheck{
+			{Name: "parsevkctl / test", State: domain.CheckStateSuccess, Bucket: domain.CheckStateSuccess},
+			{Name: "docs / optional", State: domain.CheckStateSkipped, Bucket: domain.CheckStateSuccess},
+		},
+	}
+
+	_, err := BuildTaskMergePlan(context.Background(), TaskIssueInput{
+		IssueNumber: 112,
+		Config:      deps.Config,
+		Git:         deps.Git,
+		GitHub:      deps.GitHub,
+	})
+	if err != nil {
+		t.Fatalf("BuildTaskMergePlan returned error: %v", err)
+	}
+	if deps.GitHub.checkCalls != 1 {
+		t.Fatalf("check calls = %d, want 1", deps.GitHub.checkCalls)
+	}
+	deps.assertNoWrites(t)
+}
+
+func TestTaskMergeRequireChecksBlocksZeroChecks(t *testing.T) {
+	deps := okDeps()
+	requireChecks := true
+	deps.Config.Merge.RequireChecks = &requireChecks
+	deps.GitHub.prs = []domain.PullRequest{{
+		Number: 9,
+		State:  domain.PullRequestStateOpen,
+		Base:   "fastapi-microservices-rewrite",
+		Head:   "feat/issue-112-add-read-only-task-commands",
+	}}
+	deps.GitHub.checks = domain.PullRequestChecks{PullRequestNumber: 9}
+
+	_, err := BuildTaskMergePlan(context.Background(), TaskIssueInput{
+		IssueNumber: 112,
+		Config:      deps.Config,
+		Git:         deps.Git,
+		GitHub:      deps.GitHub,
+	})
+	if err == nil || !strings.Contains(err.Error(), "pull request #9 has no checks") {
+		t.Fatalf("err = %v, want no checks error", err)
+	}
+	deps.assertNoWrites(t)
+}
+
+func TestTaskMergeRequireChecksBlocksPendingFailedAndUnknownChecks(t *testing.T) {
+	tests := []struct {
+		name  string
+		check domain.PullRequestCheck
+		want  string
+	}{
+		{
+			name:  "pending",
+			check: domain.PullRequestCheck{Name: "parsevkctl / test", State: domain.CheckStatePending, Bucket: domain.CheckStatePending},
+			want:  "pull request #9 has pending checks: parsevkctl / test",
+		},
+		{
+			name:  "failed",
+			check: domain.PullRequestCheck{Name: "frontend / typecheck", State: domain.CheckStateFailure, Bucket: domain.CheckStateFailure},
+			want:  "pull request #9 has failed checks: frontend / typecheck",
+		},
+		{
+			name:  "unknown",
+			check: domain.PullRequestCheck{Name: "ci / mystery", State: domain.CheckStateUnknown, Bucket: domain.CheckStateUnknown},
+			want:  "pull request #9 has unknown check states: ci / mystery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := okDeps()
+			requireChecks := true
+			deps.Config.Merge.RequireChecks = &requireChecks
+			deps.GitHub.prs = []domain.PullRequest{{
+				Number: 9,
+				State:  domain.PullRequestStateOpen,
+				Base:   "fastapi-microservices-rewrite",
+				Head:   "feat/issue-112-add-read-only-task-commands",
+			}}
+			deps.GitHub.checks = domain.PullRequestChecks{
+				PullRequestNumber: 9,
+				Total:             1,
+				Checks:            []domain.PullRequestCheck{tt.check},
+			}
+
+			_, err := BuildTaskMergePlan(context.Background(), TaskIssueInput{
+				IssueNumber: 112,
+				Config:      deps.Config,
+				Git:         deps.Git,
+				GitHub:      deps.GitHub,
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("err = %v, want it to contain %q", err, tt.want)
+			}
+			deps.assertNoWrites(t)
+		})
+	}
+}
+
+func TestTaskMergeRequireChecksFalseDoesNotLoadChecks(t *testing.T) {
+	deps := okDeps()
+	requireChecks := false
+	deps.Config.Merge.RequireChecks = &requireChecks
+	deps.GitHub.prs = []domain.PullRequest{{
+		Number: 9,
+		State:  domain.PullRequestStateOpen,
+		Base:   "fastapi-microservices-rewrite",
+		Head:   "feat/issue-112-add-read-only-task-commands",
+	}}
+	deps.GitHub.checkErr = errors.New("must not be called")
+
+	_, err := BuildTaskMergePlan(context.Background(), TaskIssueInput{
+		IssueNumber: 112,
+		Config:      deps.Config,
+		Git:         deps.Git,
+		GitHub:      deps.GitHub,
+	})
+	if err != nil {
+		t.Fatalf("BuildTaskMergePlan returned error: %v", err)
+	}
+	if deps.GitHub.checkCalls != 0 {
+		t.Fatalf("check calls = %d, want 0", deps.GitHub.checkCalls)
+	}
+	deps.assertNoWrites(t)
+}
+
 func assertCheck(t *testing.T, checks []DoctorCheck, name string, status CheckStatus) {
 	t.Helper()
 	for _, check := range checks {
@@ -592,6 +732,9 @@ func (f *fakeGit) HasCommitsAhead(context.Context, string, string) (bool, error)
 type fakeGitHub struct {
 	issue           domain.Issue
 	prs             []domain.PullRequest
+	checks          domain.PullRequestChecks
+	checkErr        error
+	checkCalls      int
 	project         domain.ProjectItem
 	projectErr      error
 	projectFieldErr error
@@ -632,6 +775,13 @@ func (f *fakeGitHub) MergePullRequest(context.Context, int, github.MergePullRequ
 		return nil
 	}
 	return errors.New("write call")
+}
+func (f *fakeGitHub) GetPullRequestChecks(context.Context, int) (domain.PullRequestChecks, error) {
+	f.checkCalls++
+	if f.checkErr != nil {
+		return domain.PullRequestChecks{}, f.checkErr
+	}
+	return f.checks, nil
 }
 func (f *fakeGitHub) GetProjectItem(context.Context, int) (domain.ProjectItem, error) {
 	if f.projectErr != nil {

--- a/tools/parsevkctl-go/internal/commands/write.go
+++ b/tools/parsevkctl-go/internal/commands/write.go
@@ -321,7 +321,13 @@ func BuildTaskMergePlan(ctx context.Context, input TaskIssueInput) (TaskMergePla
 		return TaskMergePlanResult{}, fmt.Errorf("pull request #%d base branch %q does not match %q", linked.Number, linked.Base, input.Config.DefaultBranch)
 	}
 	if requireChecks(input.Config) {
-		return TaskMergePlanResult{}, fmt.Errorf("merge.requireChecks=true but check status adapter is not implemented; verify checks manually or disable requireChecks in config")
+		checks, err := input.GitHub.GetPullRequestChecks(ctx, int(linked.Number))
+		if err != nil {
+			return TaskMergePlanResult{}, fmt.Errorf("get checks for pull request #%d: %w", linked.Number, err)
+		}
+		if err := validatePullRequestChecks(checks); err != nil {
+			return TaskMergePlanResult{}, err
+		}
 	}
 
 	currentState := task.DeriveState(task.LifecycleSnapshot{
@@ -443,6 +449,51 @@ Created via parsevkctl.
 
 func requireChecks(cfg config.Config) bool {
 	return cfg.Merge.RequireChecks != nil && *cfg.Merge.RequireChecks
+}
+
+func validatePullRequestChecks(checks domain.PullRequestChecks) error {
+	prNumber := checks.PullRequestNumber
+	if checks.Total == 0 || len(checks.Checks) == 0 {
+		return fmt.Errorf("pull request #%d has no checks; merge.requireChecks=true requires at least one successful check", prNumber)
+	}
+
+	pending := checkNamesByBucket(checks.Checks, domain.CheckStatePending)
+	if len(pending) > 0 {
+		return fmt.Errorf("pull request #%d has pending checks: %s", prNumber, strings.Join(pending, ", "))
+	}
+	failed := checkNamesByBucket(checks.Checks, domain.CheckStateFailure)
+	if len(failed) > 0 {
+		return fmt.Errorf("pull request #%d has failed checks: %s", prNumber, strings.Join(failed, ", "))
+	}
+	unknown := checkNamesWithUnknownState(checks.Checks)
+	if len(unknown) > 0 {
+		return fmt.Errorf("pull request #%d has unknown check states: %s; update parsevkctl check-state mapping or inspect the PR manually", prNumber, strings.Join(unknown, ", "))
+	}
+	if checks.Successful == 0 {
+		return fmt.Errorf("pull request #%d has no successful checks; merge.requireChecks=true requires at least one successful check", prNumber)
+	}
+
+	return nil
+}
+
+func checkNamesByBucket(checks []domain.PullRequestCheck, bucket domain.CheckState) []string {
+	names := []string{}
+	for _, check := range checks {
+		if check.Bucket == bucket {
+			names = append(names, check.Name)
+		}
+	}
+	return names
+}
+
+func checkNamesWithUnknownState(checks []domain.PullRequestCheck) []string {
+	names := []string{}
+	for _, check := range checks {
+		if check.State == domain.CheckStateUnknown || check.Bucket == domain.CheckStateUnknown {
+			names = append(names, check.Name)
+		}
+	}
+	return names
 }
 
 func mergeStrategy(cfg config.Config) string {

--- a/tools/parsevkctl-go/internal/domain/domain.go
+++ b/tools/parsevkctl-go/internal/domain/domain.go
@@ -47,6 +47,32 @@ type PullRequest struct {
 	Head   string
 }
 
+type CheckState string
+
+const (
+	CheckStateSuccess CheckState = "success"
+	CheckStatePending CheckState = "pending"
+	CheckStateFailure CheckState = "failure"
+	CheckStateSkipped CheckState = "skipped"
+	CheckStateUnknown CheckState = "unknown"
+)
+
+type PullRequestChecks struct {
+	PullRequestNumber int
+	Total             int
+	Successful        int
+	Pending           int
+	Failed            int
+	Skipped           int
+	Checks            []PullRequestCheck
+}
+
+type PullRequestCheck struct {
+	Name   string
+	State  CheckState
+	Bucket CheckState
+}
+
 type ProjectStatus string
 
 const (

--- a/tools/parsevkctl-go/internal/github/github.go
+++ b/tools/parsevkctl-go/internal/github/github.go
@@ -14,6 +14,7 @@ type Adapter interface {
 	ListPullRequests(ctx context.Context, filter PullRequestFilter) ([]domain.PullRequest, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (domain.PullRequest, error)
 	MergePullRequest(ctx context.Context, number int, input MergePullRequestInput) error
+	GetPullRequestChecks(ctx context.Context, prNumber int) (domain.PullRequestChecks, error)
 
 	GetProjectItem(ctx context.Context, issueNumber int) (domain.ProjectItem, error)
 	AddProjectItem(ctx context.Context, issueNumber int) error

--- a/tools/parsevkctl-go/internal/github/parse.go
+++ b/tools/parsevkctl-go/internal/github/parse.go
@@ -91,6 +91,17 @@ func parsePullRequestChecksText(prNumber int, output string) (domain.PullRequest
 		if trimmed == "" {
 			continue
 		}
+		if strings.Contains(line, "\t") {
+			columns := strings.Split(line, "\t")
+			name := strings.TrimSpace(columns[0])
+			state := ""
+			if len(columns) > 1 {
+				state = strings.TrimSpace(columns[1])
+			}
+			checks = append(checks, pullRequestCheckFromParts("", name, state, ""))
+			continue
+		}
+
 		fields := strings.Fields(trimmed)
 		if len(fields) < 2 {
 			checks = append(checks, pullRequestCheckFromParts("", trimmed, "", ""))
@@ -98,13 +109,6 @@ func parsePullRequestChecksText(prNumber int, output string) (domain.PullRequest
 		}
 
 		stateIndex := len(fields) - 1
-		for i, field := range fields {
-			if classifyCheckState(field) != domain.CheckStateUnknown {
-				stateIndex = i
-				break
-			}
-		}
-
 		name := strings.Join(fields[:stateIndex], " ")
 		if strings.TrimSpace(name) == "" {
 			name = trimmed

--- a/tools/parsevkctl-go/internal/github/parse.go
+++ b/tools/parsevkctl-go/internal/github/parse.go
@@ -31,6 +31,13 @@ type pullRequestJSON struct {
 	Head     string  `json:"headRefName"`
 }
 
+type pullRequestCheckJSON struct {
+	Name     string `json:"name"`
+	State    string `json:"state"`
+	Bucket   string `json:"bucket"`
+	Workflow string `json:"workflow"`
+}
+
 func parseIssueJSON(data []byte) (domain.Issue, error) {
 	var raw issueJSON
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -63,6 +70,51 @@ func parsePullRequestsJSON(data []byte) ([]domain.PullRequest, error) {
 	return prs, nil
 }
 
+func parsePullRequestChecksJSON(prNumber int, data []byte) (domain.PullRequestChecks, error) {
+	var raw []pullRequestCheckJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return domain.PullRequestChecks{}, fmt.Errorf("parse pull request checks JSON: %w", err)
+	}
+
+	checks := make([]domain.PullRequestCheck, 0, len(raw))
+	for _, item := range raw {
+		checks = append(checks, pullRequestCheckFromParts(item.Workflow, item.Name, item.State, item.Bucket))
+	}
+	return summarizePullRequestChecks(prNumber, checks), nil
+}
+
+func parsePullRequestChecksText(prNumber int, output string) (domain.PullRequestChecks, error) {
+	lines := strings.Split(output, "\n")
+	checks := make([]domain.PullRequestCheck, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		fields := strings.Fields(trimmed)
+		if len(fields) < 2 {
+			checks = append(checks, pullRequestCheckFromParts("", trimmed, "", ""))
+			continue
+		}
+
+		stateIndex := len(fields) - 1
+		for i, field := range fields {
+			if classifyCheckState(field) != domain.CheckStateUnknown {
+				stateIndex = i
+				break
+			}
+		}
+
+		name := strings.Join(fields[:stateIndex], " ")
+		if strings.TrimSpace(name) == "" {
+			name = trimmed
+		}
+		checks = append(checks, pullRequestCheckFromParts("", name, fields[stateIndex], ""))
+	}
+
+	return summarizePullRequestChecks(prNumber, checks), nil
+}
+
 func issueFromJSON(raw issueJSON) domain.Issue {
 	return domain.Issue{
 		ID:     domain.TaskID(raw.Number),
@@ -86,6 +138,72 @@ func issueLabelsFromJSON(rawLabels []struct {
 	}
 
 	return labels
+}
+
+func pullRequestCheckFromParts(workflow string, name string, state string, bucketValue string) domain.PullRequestCheck {
+	checkName := strings.TrimSpace(name)
+	workflowName := strings.TrimSpace(workflow)
+	if workflowName != "" && checkName != "" && !strings.EqualFold(workflowName, checkName) {
+		checkName = workflowName + " / " + checkName
+	}
+	if checkName == "" {
+		checkName = "(unnamed check)"
+	}
+
+	normalized := classifyCheckState(state)
+	bucket := classifyCheckState(bucketValue)
+	if bucket == domain.CheckStateUnknown {
+		bucket = normalized
+	}
+	if bucket == domain.CheckStateSkipped {
+		bucket = domain.CheckStateSuccess
+	}
+
+	return domain.PullRequestCheck{
+		Name:   checkName,
+		State:  normalized,
+		Bucket: bucket,
+	}
+}
+
+func classifyCheckState(state string) domain.CheckState {
+	normalized := strings.ToUpper(strings.TrimSpace(state))
+	normalized = strings.TrimSuffix(normalized, ":")
+
+	switch normalized {
+	case "SUCCESS", "PASSED", "PASS", "COMPLETED":
+		return domain.CheckStateSuccess
+	case "SKIPPED", "SKIPPING", "NEUTRAL":
+		return domain.CheckStateSkipped
+	case "PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED":
+		return domain.CheckStatePending
+	case "FAILURE", "FAILED", "FAIL", "ERROR", "CANCELLED", "CANCEL", "TIMED_OUT", "ACTION_REQUIRED":
+		return domain.CheckStateFailure
+	default:
+		return domain.CheckStateUnknown
+	}
+}
+
+func summarizePullRequestChecks(prNumber int, checks []domain.PullRequestCheck) domain.PullRequestChecks {
+	summary := domain.PullRequestChecks{
+		PullRequestNumber: prNumber,
+		Total:             len(checks),
+		Checks:            checks,
+	}
+	for _, check := range checks {
+		switch check.Bucket {
+		case domain.CheckStateSuccess:
+			summary.Successful++
+		case domain.CheckStatePending:
+			summary.Pending++
+		case domain.CheckStateFailure:
+			summary.Failed++
+		}
+		if check.State == domain.CheckStateSkipped {
+			summary.Skipped++
+		}
+	}
+	return summary
 }
 
 func pullRequestFromJSON(raw pullRequestJSON) domain.PullRequest {

--- a/tools/parsevkctl-go/internal/github/shell.go
+++ b/tools/parsevkctl-go/internal/github/shell.go
@@ -16,6 +16,7 @@ import (
 const (
 	issueJSONFields       = "number,title,state,url,labels"
 	pullRequestJSONFields = "number,title,state,isDraft,mergedAt,url,baseRefName,headRefName"
+	checkJSONFields       = "name,state,bucket,workflow,startedAt,completedAt,link"
 )
 
 type commandResult struct {
@@ -184,6 +185,36 @@ func (adapter *ShellAdapter) MergePullRequest(ctx context.Context, number int, i
 
 	_, err := adapter.runGH(ctx, "merge pull request", args...)
 	return err
+}
+
+func (adapter *ShellAdapter) GetPullRequestChecks(ctx context.Context, prNumber int) (domain.PullRequestChecks, error) {
+	if err := validateNumber("pull request number", prNumber); err != nil {
+		return domain.PullRequestChecks{}, err
+	}
+
+	result, err := adapter.runGH(ctx, "get pull request checks", "pr", "checks", strconv.Itoa(prNumber), "--json", checkJSONFields)
+	if strings.TrimSpace(result.stdout) != "" {
+		checks, parseErr := parsePullRequestChecksJSON(prNumber, []byte(result.stdout))
+		if parseErr == nil {
+			return checks, nil
+		}
+		if err == nil {
+			return domain.PullRequestChecks{}, parseErr
+		}
+	}
+	if err == nil {
+		return parsePullRequestChecksJSON(prNumber, []byte(result.stdout))
+	}
+
+	textResult, textErr := adapter.runGH(ctx, "get pull request checks", "pr", "checks", strconv.Itoa(prNumber))
+	if strings.TrimSpace(textResult.stdout) != "" {
+		return parsePullRequestChecksText(prNumber, textResult.stdout)
+	}
+	if textErr != nil {
+		return domain.PullRequestChecks{}, fmt.Errorf("get pull request checks JSON failed: %v; text fallback failed: %w", err, textErr)
+	}
+
+	return parsePullRequestChecksText(prNumber, textResult.stdout)
 }
 
 func (adapter *ShellAdapter) GetProjectItem(ctx context.Context, issueNumber int) (domain.ProjectItem, error) {

--- a/tools/parsevkctl-go/internal/github/shell_test.go
+++ b/tools/parsevkctl-go/internal/github/shell_test.go
@@ -117,6 +117,26 @@ docs / optional	skipping	0s	https://github.test/checks/4`)
 	}
 }
 
+func TestParsePullRequestChecksTextPrefersTabSeparatedStateColumn(t *testing.T) {
+	t.Parallel()
+
+	checks, err := parsePullRequestChecksText(17, "pending migrations / test\tpass\t1m\thttps://github.test/checks/1\nfail-safe check\tpass\t1m\thttps://github.test/checks/2")
+	if err != nil {
+		t.Fatalf("parsePullRequestChecksText returned error: %v", err)
+	}
+
+	if checks.Total != 2 || checks.Successful != 2 || checks.Pending != 0 || checks.Failed != 0 {
+		t.Fatalf("unexpected totals: %#v", checks)
+	}
+	want := []domain.PullRequestCheck{
+		{Name: "pending migrations / test", State: domain.CheckStateSuccess, Bucket: domain.CheckStateSuccess},
+		{Name: "fail-safe check", State: domain.CheckStateSuccess, Bucket: domain.CheckStateSuccess},
+	}
+	if !reflect.DeepEqual(checks.Checks, want) {
+		t.Fatalf("checks = %#v, want %#v", checks.Checks, want)
+	}
+}
+
 func TestCommandArguments(t *testing.T) {
 	t.Parallel()
 

--- a/tools/parsevkctl-go/internal/github/shell_test.go
+++ b/tools/parsevkctl-go/internal/github/shell_test.go
@@ -69,6 +69,54 @@ func TestParsePullRequestsJSON(t *testing.T) {
 	}
 }
 
+func TestParsePullRequestChecksJSONBucketsStates(t *testing.T) {
+	t.Parallel()
+
+	checks, err := parsePullRequestChecksJSON(17, []byte(`[
+		{"name":"test","state":"SUCCESS","workflow":"parsevkctl"},
+		{"name":"typecheck","state":"IN_PROGRESS","workflow":"frontend"},
+		{"name":"lint","state":"FAILED","workflow":"backend"},
+		{"name":"optional","state":"NEUTRAL","workflow":"docs"},
+		{"name":"mystery","state":"STALE","workflow":"ci"}
+	]`))
+	if err != nil {
+		t.Fatalf("parsePullRequestChecksJSON returned error: %v", err)
+	}
+
+	if checks.PullRequestNumber != 17 {
+		t.Fatalf("pull request number = %d, want 17", checks.PullRequestNumber)
+	}
+	if checks.Total != 5 || checks.Successful != 2 || checks.Pending != 1 || checks.Failed != 1 || checks.Skipped != 1 {
+		t.Fatalf("unexpected totals: %#v", checks)
+	}
+	want := []domain.PullRequestCheck{
+		{Name: "parsevkctl / test", State: domain.CheckStateSuccess, Bucket: domain.CheckStateSuccess},
+		{Name: "frontend / typecheck", State: domain.CheckStatePending, Bucket: domain.CheckStatePending},
+		{Name: "backend / lint", State: domain.CheckStateFailure, Bucket: domain.CheckStateFailure},
+		{Name: "docs / optional", State: domain.CheckStateSkipped, Bucket: domain.CheckStateSuccess},
+		{Name: "ci / mystery", State: domain.CheckStateUnknown, Bucket: domain.CheckStateUnknown},
+	}
+	if !reflect.DeepEqual(checks.Checks, want) {
+		t.Fatalf("checks = %#v, want %#v", checks.Checks, want)
+	}
+}
+
+func TestParsePullRequestChecksTextBucketsStates(t *testing.T) {
+	t.Parallel()
+
+	checks, err := parsePullRequestChecksText(17, `parsevkctl / test	pass	1m	https://github.test/checks/1
+frontend / typecheck	pending	0s	https://github.test/checks/2
+backend / lint	fail	10s	https://github.test/checks/3
+docs / optional	skipping	0s	https://github.test/checks/4`)
+	if err != nil {
+		t.Fatalf("parsePullRequestChecksText returned error: %v", err)
+	}
+
+	if checks.Total != 4 || checks.Successful != 2 || checks.Pending != 1 || checks.Failed != 1 || checks.Skipped != 1 {
+		t.Fatalf("unexpected totals: %#v", checks)
+	}
+}
+
 func TestCommandArguments(t *testing.T) {
 	t.Parallel()
 
@@ -106,6 +154,14 @@ func TestCommandArguments(t *testing.T) {
 			args: []string{"pr", "list", "--state", "open", "--head", "feature", "--base", "main", "--search", "issue 108", "--json", "number,title,state,isDraft,mergedAt,url,baseRefName,headRefName"},
 		},
 		{
+			name: "get pull request checks",
+			run: func(adapter *ShellAdapter) error {
+				_, err := adapter.GetPullRequestChecks(context.Background(), 7)
+				return err
+			},
+			args: []string{"pr", "checks", "7", "--json", "name,state,bucket,workflow,startedAt,completedAt,link"},
+		},
+		{
 			name: "merge pull request",
 			run: func(adapter *ShellAdapter) error {
 				return adapter.MergePullRequest(context.Background(), 7, MergePullRequestInput{
@@ -136,6 +192,22 @@ func TestCommandArguments(t *testing.T) {
 				t.Fatalf("args = %#v, want %#v", got, tt.args)
 			}
 		})
+	}
+}
+
+func TestGetPullRequestChecksParsesJSONStdoutWhenGHReturnsNonZero(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
+		return commandResult{stdout: `[{"name":"typecheck","state":"COMPLETED","bucket":"fail","workflow":"frontend"}]`}, fakeExitError{code: 1}
+	})
+
+	checks, err := adapter.GetPullRequestChecks(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("GetPullRequestChecks returned error: %v", err)
+	}
+	if checks.Failed != 1 {
+		t.Fatalf("failed checks = %d, want 1; checks=%#v", checks.Failed, checks)
 	}
 }
 
@@ -325,6 +397,9 @@ func (err fakeExitError) ExitCode() int {
 }
 
 func commandOutputFor(args []string) string {
+	if len(args) >= 3 && args[0] == "pr" && args[1] == "checks" {
+		return `[{"name":"test","state":"SUCCESS","workflow":"parsevkctl"}]`
+	}
 	if len(args) >= 2 && args[0] == "pr" && (args[1] == "list" || args[1] == "create") {
 		if args[1] == "list" {
 			return `[{"number":7,"title":"PR","state":"OPEN","isDraft":false,"mergedAt":null}]`

--- a/tools/parsevkctl-go/internal/planner/executor_test.go
+++ b/tools/parsevkctl-go/internal/planner/executor_test.go
@@ -234,6 +234,10 @@ func (f *fakeGitHubAdapter) MergePullRequest(context.Context, int, github.MergeP
 	return nil
 }
 
+func (f *fakeGitHubAdapter) GetPullRequestChecks(context.Context, int) (domain.PullRequestChecks, error) {
+	return domain.PullRequestChecks{}, nil
+}
+
 func (f *fakeGitHubAdapter) GetProjectItem(context.Context, int) (domain.ProjectItem, error) {
 	return domain.ProjectItem{}, nil
 }


### PR DESCRIPTION
Closes #179

## Summary
- Add PR check-status domain types and GitHub adapter support for `gh pr checks`.
- Enforce `merge.requireChecks=true` in `task merge`, blocking missing, pending, failed, and unknown checks.
- Prefer tab-separated text fallback parsing so status-like words in check names are not treated as states.
- Document `merge.requireChecks` behavior without enabling it in the project config.

## Test plan
- [x] `go test ./...`
- [x] `go build -o bin/parsevkctl.exe ./cmd/parsevkctl`
- [x] `./bin/parsevkctl.exe config validate`

## Risk
- Low: `merge.requireChecks=false` still skips check enforcement; new behavior only runs when enabled.
