### PR TITLE
fix(docker): restore deploy compose startup

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -7,9 +7,13 @@ x-api-build: &api-build
     NPM_REGISTRY_FALLBACK: ${NPM_REGISTRY_FALLBACK:-https://registry.npmjs.org/}
 
 x-api-environment: &api-environment
-  DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
-  TGMBASE_DATABASE_URL: ${TGMBASE_DATABASE_URL:-postgresql://postgres:postgres@db:5432/tgmbase?schema=public}
+  DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db:5432/${POSTGRES_DB:?POSTGRES_DB is required}?schema=public
+  TGMBASE_DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@db:5432/tgmbase?schema=public
   MONITOR_DATABASE_URL: ${MONITOR_DATABASE_URL:-}
+  REDIS_HOST: redis
+  REDIS_PORT: 6379
+  BULLMQ_HOST: redis
+  BULLMQ_PORT: 6379
 
 services:
   db:
@@ -46,7 +50,7 @@ services:
       - default
 
   identity-db:
-    image: postgres:15.18-alpine
+    image: postgres:16.14
     platform: linux/amd64
     restart: always
     ports:
@@ -161,7 +165,7 @@ services:
       - default
 
   tasks-db:
-    image: postgres:15.18-alpine
+    image: postgres:16.14
     platform: linux/amd64
     restart: always
     ports:
@@ -223,7 +227,7 @@ services:
       - default
 
   vk-db:
-    image: postgres:15.18-alpine
+    image: postgres:16.14
     platform: linux/amd64
     restart: always
     ports:
@@ -292,7 +296,7 @@ services:
       - default
 
   content-db:
-    image: postgres:15.18-alpine
+    image: postgres:16.14
     platform: linux/amd64
     restart: always
     ports:
@@ -493,7 +497,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://localhost:80 || exit 1",
+          "wget --no-verbose --tries=1 --spider http://127.0.0.1:80 || exit 1",
         ]
       interval: 10s
       timeout: 5s

--- a/docker/db-backup/Dockerfile
+++ b/docker/db-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:15.18-alpine
+FROM postgres:16.14-alpine
 
 RUN apk add --no-cache bash tzdata
 

--- a/docs/DOCKER_IMAGE_VERSIONS.md
+++ b/docs/DOCKER_IMAGE_VERSIONS.md
@@ -7,8 +7,9 @@ silently after `docker compose pull` or image rebuilds.
 
 | Component | Image tag |
 | --- | --- |
-| PostgreSQL 15 deploy databases and backup image | `postgres:15.18-alpine` |
-| PostgreSQL 16 local service databases | `postgres:16.14` |
+| PostgreSQL legacy deploy database | `postgres:15.18-alpine` |
+| PostgreSQL deploy service databases and local service databases | `postgres:16.14` |
+| PostgreSQL backup image | `postgres:16.14-alpine` |
 | Redis | `redis:7.4.9-alpine` |
 | Kafka | `apache/kafka:4.1.0` |
 | Prometheus | `prom/prometheus:v3.11.3` |

--- a/services/content-service/pyproject.toml
+++ b/services/content-service/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "alembic>=1.13",
   "asyncpg>=0.29",
   "fastapi>=0.115",
+  "httpx>=0.27",
   "pydantic-settings>=2.4",
   "sqlalchemy[asyncio]>=2.0",
   "uvicorn[standard]>=0.30",


### PR DESCRIPTION
Closes #182

## Summary
- Keep deploy PostgreSQL pins compatible with existing mixed major-version volumes.
- Force container runtime DB/Redis URLs to use compose service hosts instead of host-local `.env` values.
- Add missing `httpx` runtime dependency for content-service and fix frontend healthcheck IPv4 target.

## Validation
- [x] `docker compose -f docker-compose.deploy.yml config --quiet`
- [x] `docker compose -f docker-compose.deploy.yml up -d --build`
- [x] `docker compose -f docker-compose.deploy.yml ps` shows app services healthy
- [x] stale floating-tag grep returned no matches
- [x] `git diff --check`

## Notes
- Remaining API warnings are configuration-related: missing OK credentials and invalid VK token for external health checks.