### PR TITLE
docs(ai-workflow): add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-task.yml
+++ b/.github/ISSUE_TEMPLATE/ai-task.yml
@@ -1,0 +1,108 @@
+name: AI-assisted task
+description: Plan a scoped task for the parseVK AI-assisted development workflow.
+title: "MBP-XXX: "
+labels:
+  - ai:ready
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for tasks that should move through the Issue -> AI branch -> PR -> review -> merge workflow.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: Describe the outcome this task should achieve.
+      placeholder: Add repository templates and workflow documentation for AI-assisted development.
+    validations:
+      required: true
+
+  - type: input
+    id: service
+    attributes:
+      label: Service
+      description: Name the affected service, tool, or area.
+      placeholder: parsevkctl
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List the files, behavior, or documentation that are in scope.
+      placeholder: |
+        - Add ...
+        - Update ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope
+      description: List areas the AI agent must not change.
+      placeholder: |
+        - Do not change application code.
+        - Do not change CI/CD workflows.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Use checkboxes for concrete completion requirements.
+      placeholder: |
+        - [ ] File exists
+        - [ ] No application code is changed
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation-commands
+    attributes:
+      label: Validation Commands
+      description: Commands the agent should run before opening the PR.
+      placeholder: |
+        ```bash
+        git diff --name-only
+        ```
+    validations:
+      required: true
+
+  - type: dropdown
+    id: risk-level
+    attributes:
+      label: Risk Level
+      description: Estimate the risk if the task is implemented exactly as scoped.
+      options:
+        - low
+        - medium
+        - high
+    validations:
+      required: true
+
+  - type: input
+    id: expected-ai-sessions
+    attributes:
+      label: Expected AI Sessions
+      description: Estimate how many AI sessions should be needed.
+      placeholder: "1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: required-handoff
+    attributes:
+      label: Required Handoff
+      description: Information the agent must provide when the task is ready for review.
+      value: |
+        - summary
+        - changed files
+        - validation commands run
+        - risks
+        - next suggested issue
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+# Closes
+
+Closes #issue
+
+## Summary
+
+-
+
+## Changed Files
+
+-
+
+## Validation
+
+- [ ]
+
+## Risks
+
+-
+
+## AI Handoff
+
+- AI sessions used:
+- Key decisions:
+- Follow-up issues:
+- Reviewer notes:

--- a/docs/ai-workflow/ISSUE_WORKFLOW.md
+++ b/docs/ai-workflow/ISSUE_WORKFLOW.md
@@ -1,0 +1,116 @@
+# AI Issue Workflow
+
+This workflow keeps parseVK AI-assisted development tasks scoped, reviewable,
+and traceable from GitHub Issue to merged pull request.
+
+## Issue Creation
+
+Create AI-ready tasks with the repository issue template:
+
+```text
+.github/ISSUE_TEMPLATE/ai-task.yml
+```
+
+Each issue must define:
+
+- goal
+- service or repository area
+- scope
+- out of scope
+- acceptance criteria
+- validation commands
+- risk level
+- expected AI sessions
+- required handoff
+
+The issue body is the source of truth for the AI agent. Keep it specific enough
+that the agent can implement the task without expanding scope.
+
+## Labels
+
+Use labels to make triage and automation predictable:
+
+- `ai:ready` marks work that is ready for an AI session.
+- `type:*` labels describe the kind of change, such as `type:docs`,
+  `type:infra`, `type:fix`, or `type:feature`.
+- `service:*` labels identify the affected service, tool, or repository area.
+- `risk:*` labels describe expected review and merge risk.
+
+Prefer one clear service label and one clear risk label per task.
+
+## Starting Work
+
+Use the local workflow helper from `tools/parsevkctl-go`:
+
+```powershell
+cd tools/parsevkctl-go
+go run ./cmd/parsevkctl task create "Task title" --body "Task body"
+go run ./cmd/parsevkctl task start ISSUE_NUMBER
+```
+
+For an existing issue:
+
+```powershell
+cd tools/parsevkctl-go
+go run ./cmd/parsevkctl task start ISSUE_NUMBER
+```
+
+`task start` moves the Project item to `In Progress`, updates the configured
+default branch, and creates the task branch.
+
+## Branch Naming
+
+Task branches should follow the repository branch naming convention:
+
+```text
+<type>/issue-<number>-<short-kebab-summary>
+```
+
+Examples:
+
+```text
+docs/issue-185-add-github-ai-workflow-templates
+fix/issue-130-parsevkctl-branch-cleanup
+feat/issue-127-moderation-service
+```
+
+The branch type should match the primary change type.
+
+## AI Session Expectations
+
+Each AI session should:
+
+- follow the issue scope strictly
+- avoid unrelated refactors
+- avoid application code changes unless the issue explicitly allows them
+- preserve user changes already present in the working tree
+- run the validation commands listed in the issue
+- stop and ask for direction if the task requires work outside scope
+
+Low-risk documentation or template tasks should usually fit in one AI session.
+Higher-risk tasks should define smaller follow-up issues instead of growing the
+current branch.
+
+## Handoff Requirements
+
+Before a PR is ready for review, the AI agent should provide:
+
+- summary
+- changed files
+- validation commands run
+- risks
+- next suggested issue
+
+The handoff should also mention skipped validation and why it was skipped.
+
+## Pull Request Creation
+
+After implementation, validation, and commit:
+
+```powershell
+cd tools/parsevkctl-go
+go run ./cmd/parsevkctl task pr ISSUE_NUMBER
+```
+
+The PR body must include `Closes #ISSUE_NUMBER` so the issue can close when the
+PR is merged.

--- a/docs/ai-workflow/PR_REVIEW_WORKFLOW.md
+++ b/docs/ai-workflow/PR_REVIEW_WORKFLOW.md
@@ -1,0 +1,80 @@
+# AI Pull Request Review Workflow
+
+This workflow separates local ChatGPT review from GitHub review actions. It
+keeps repository review state intentional and avoids accidental approvals or
+change requests.
+
+## Review Order
+
+Start with ChatGPT review in the local Codex session.
+
+The AI reviewer should inspect the diff, check the issue scope, and report
+findings in the chat first. Do not submit a GitHub PR review until the user
+explicitly asks for it.
+
+Recommended local checks:
+
+```powershell
+git diff --name-only
+git diff
+```
+
+Run any validation commands required by the issue or PR body before making a
+merge recommendation.
+
+## GitHub Review Requires Explicit Command
+
+Only submit a GitHub review after the user gives an explicit instruction such
+as:
+
+```text
+approve this PR on GitHub
+request changes on GitHub
+leave a GitHub review comment
+```
+
+General review requests, such as "review this PR", mean review in chat only.
+
+## Review Outcomes
+
+Use GitHub review states carefully:
+
+- Approve only when the PR matches the issue scope, validation is sufficient,
+  risks are acceptable, and no blocking findings remain.
+- Request changes when there is a blocking correctness, security, scope, or
+  validation issue that must be fixed before merge.
+- Comment only when feedback is non-blocking, informational, or needs human
+  judgment.
+
+When in doubt, comment in chat first and ask the user before changing GitHub
+review state.
+
+## Merge Recommendation Rules
+
+Recommend merge only when:
+
+- the PR includes `Closes #ISSUE_NUMBER`
+- the PR is not a draft
+- changed files match the issue scope
+- local validation was run or skipped with a clear reason
+- GitHub checks passed, if checks exist
+- no secrets, local environment files, or private configuration were added
+- no application code was changed for documentation-only tasks
+- no blocking review findings remain
+
+Do not recommend merge when the PR changes GitHub Actions workflows,
+deployment configuration, authentication or security logic, secrets,
+environment configuration, database migrations, or a large refactor unless the
+user explicitly confirms that review and merge should proceed.
+
+## Review Handoff
+
+Every review summary should include:
+
+- blocking findings, if any
+- non-blocking notes, if useful
+- validation reviewed
+- risk assessment
+- clear recommendation: approve, request changes, comment only, or hold
+
+Keep the recommendation tied to the issue scope and validation evidence.


### PR DESCRIPTION
Closes #185

## Summary
- Added an AI task issue form for scoped GitHub Issue creation.
- Added the default PR template with linked issue, validation, risk, and AI handoff sections.
- Documented the parseVK AI issue workflow and PR review workflow.

## Changed Files
- `.github/ISSUE_TEMPLATE/ai-task.yml`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `docs/ai-workflow/ISSUE_WORKFLOW.md`
- `docs/ai-workflow/PR_REVIEW_WORKFLOW.md`

## Validation
- [x] `git diff --name-only`
- [x] `git diff --cached --name-only`
- [x] `git diff --cached --check`

## Risks
- Low: documentation/templates only; no application code, Docker, CI, service code, frontend code, or parsevkctl behavior changed.

## AI Handoff
- AI sessions used: 1
- Key decisions: did not create `docs/COMMANDS.md` because it does not exist; did not add repository labels because requested labels are not present in the repo and label creation is outside this task scope.
- Follow-up issues: add repository label taxonomy for `type:*`, `service:*`, `risk:*`, and `ai:*` labels if the team wants templates and issues to auto-apply them.
- Reviewer notes: review can focus on wording, issue form completeness, and PR review rules.