### PR TITLE
feat(parsevkctl): add labels bootstrap command

### DIFF
--- a/tools/parsevkctl-go/internal/cli/cli.go
+++ b/tools/parsevkctl-go/internal/cli/cli.go
@@ -48,6 +48,9 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	case "doctor":
 		return runDoctor(opts, stdout, stderr)
 
+	case "labels":
+		return runLabels(rest[1:], opts, stdout, stderr)
+
 	case "task":
 		return runTask(rest[1:], opts, stdout, stderr)
 
@@ -56,6 +59,25 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		printHelp(stderr)
 		return 2
 	}
+}
+
+func runLabels(args []string, opts options, stdout io.Writer, stderr io.Writer) int {
+	if len(args) != 1 || args[0] != "bootstrap" {
+		fmt.Fprintln(stderr, "Error: labels command requires bootstrap")
+		fmt.Fprintln(stderr, "Usage: parsevkctl labels bootstrap [--dry-run] [--json]")
+		return 2
+	}
+	cfg, ok := loadCommandConfig(opts, stderr)
+	if !ok {
+		return 1
+	}
+	return commands.RunLabelsBootstrap(context.Background(), commands.LabelsBootstrapRunInput{
+		GitHub: github.NewShellAdapterWithConfig(cfg),
+		DryRun: opts.dryRun,
+		JSON:   opts.jsonOutput,
+		Stdout: stdout,
+		Stderr: stderr,
+	})
 }
 
 func runDoctor(opts options, stdout io.Writer, stderr io.Writer) int {
@@ -358,6 +380,7 @@ Usage:
   parsevkctl --version
   parsevkctl config validate [--config <path>] [--json]
   parsevkctl doctor [--config <path>] [--json]
+  parsevkctl labels bootstrap [--config <path>] [--dry-run] [--json]
   parsevkctl task status <issue> [--config <path>] [--json]
   parsevkctl task sync <issue> [--config <path>] [--json]
   parsevkctl task create "Title" [--body "..."] [--config <path>] [--dry-run] [--json]
@@ -368,6 +391,7 @@ Usage:
 Commands:
   config validate   Validate parsevkctl config without GitHub or git side effects
   doctor            Check local config, git and GitHub read access
+  labels bootstrap  Create missing standard GitHub labels for parseVK workflow
   task status       Show read-only task state summary
   task sync         Preview task state drift and suggested fixes
   task create       Create a GitHub issue and optionally add it to the Project

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -731,9 +731,12 @@ func (f *fakeGit) HasCommitsAhead(context.Context, string, string) (bool, error)
 
 type fakeGitHub struct {
 	issue           domain.Issue
+	labels          []github.Label
+	createdLabels   []github.Label
 	prs             []domain.PullRequest
 	checks          domain.PullRequestChecks
 	checkErr        error
+	createLabelErr  error
 	checkCalls      int
 	project         domain.ProjectItem
 	projectErr      error
@@ -755,6 +758,20 @@ func (f *fakeGitHub) CreateIssue(context.Context, github.CreateIssueInput) (doma
 func (f *fakeGitHub) CloseIssue(context.Context, int, string) error {
 	f.writeCalls = append(f.writeCalls, "CloseIssue")
 	if f.allowWrites {
+		return nil
+	}
+	return errors.New("write call")
+}
+func (f *fakeGitHub) ListLabels(context.Context) ([]github.Label, error) {
+	return f.labels, nil
+}
+func (f *fakeGitHub) CreateLabel(_ context.Context, label github.Label) error {
+	f.writeCalls = append(f.writeCalls, "CreateLabel")
+	if f.createLabelErr != nil {
+		return f.createLabelErr
+	}
+	if f.allowWrites {
+		f.createdLabels = append(f.createdLabels, label)
 		return nil
 	}
 	return errors.New("write call")

--- a/tools/parsevkctl-go/internal/commands/labels.go
+++ b/tools/parsevkctl-go/internal/commands/labels.go
@@ -1,0 +1,122 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/github"
+)
+
+type LabelsBootstrapRunInput struct {
+	GitHub github.Adapter
+	DryRun bool
+	JSON   bool
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+type LabelsBootstrapResult struct {
+	DryRun      bool                  `json:"dryRun"`
+	Created     []github.Label        `json:"created"`
+	Existing    []github.Label        `json:"existing"`
+	WouldCreate []github.Label        `json:"wouldCreate,omitempty"`
+	Failed      []LabelBootstrapError `json:"failed"`
+}
+
+type LabelBootstrapError struct {
+	Label string `json:"label"`
+	Error string `json:"error"`
+}
+
+func RunLabelsBootstrap(ctx context.Context, input LabelsBootstrapRunInput) int {
+	result, err := BootstrapLabels(ctx, input.GitHub, input.DryRun)
+	if err != nil {
+		writeError(input.Stderr, err)
+		return 1
+	}
+	if input.JSON {
+		return renderJSON(input.Stdout, result)
+	}
+	renderLabelsBootstrap(input.Stdout, result)
+	if len(result.Failed) > 0 {
+		return 1
+	}
+	return 0
+}
+
+func BootstrapLabels(ctx context.Context, gh github.Adapter, dryRun bool) (LabelsBootstrapResult, error) {
+	existing, err := gh.ListLabels(ctx)
+	if err != nil {
+		return LabelsBootstrapResult{}, fmt.Errorf("list labels: %w", err)
+	}
+
+	existingByName := map[string]github.Label{}
+	for _, label := range existing {
+		existingByName[label.Name] = label
+	}
+
+	result := LabelsBootstrapResult{DryRun: dryRun}
+	for _, label := range github.StandardLabels() {
+		if existingLabel, ok := existingByName[label.Name]; ok {
+			result.Existing = append(result.Existing, existingLabel)
+			continue
+		}
+		if dryRun {
+			result.WouldCreate = append(result.WouldCreate, label)
+			continue
+		}
+		if err := gh.CreateLabel(ctx, label); err != nil {
+			if errors.Is(err, github.ErrLabelAlreadyExists) {
+				result.Existing = append(result.Existing, label)
+				continue
+			}
+			result.Failed = append(result.Failed, LabelBootstrapError{
+				Label: label.Name,
+				Error: err.Error(),
+			})
+			continue
+		}
+		result.Created = append(result.Created, label)
+	}
+
+	return result, nil
+}
+
+func renderLabelsBootstrap(w io.Writer, result LabelsBootstrapResult) {
+	out := output(w)
+	fmt.Fprintln(out, "parsevkctl labels bootstrap")
+	if result.DryRun {
+		fmt.Fprintln(out, "Mode: dry-run")
+	}
+	printLabelGroup(out, "Created labels:", labelNames(result.Created))
+	printLabelGroup(out, "Would create labels:", labelNames(result.WouldCreate))
+	printLabelGroup(out, "Existing labels:", labelNames(result.Existing))
+	if len(result.Failed) == 0 {
+		fmt.Fprintln(out, "Failed labels: none")
+		return
+	}
+	fmt.Fprintln(out, "Failed labels:")
+	for _, failed := range result.Failed {
+		fmt.Fprintf(out, "- %s: %s\n", failed.Label, failed.Error)
+	}
+}
+
+func printLabelGroup(w io.Writer, title string, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	fmt.Fprintln(w, title)
+	for _, name := range names {
+		fmt.Fprintln(w, "-", name)
+	}
+}
+
+func labelNames(labels []github.Label) []string {
+	names := make([]string, len(labels))
+	for i, label := range labels {
+		names[i] = label.Name
+	}
+	return names
+}

--- a/tools/parsevkctl-go/internal/commands/labels_test.go
+++ b/tools/parsevkctl-go/internal/commands/labels_test.go
@@ -1,0 +1,157 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/github"
+)
+
+func TestLabelsBootstrapDryRunDoesNotWriteAndReportsWouldCreate(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.labels = []github.Label{{Name: "type:feature"}}
+
+	var out bytes.Buffer
+	exit := RunLabelsBootstrap(context.Background(), LabelsBootstrapRunInput{
+		GitHub: deps.GitHub,
+		DryRun: true,
+		Stdout: &out,
+	})
+
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if len(deps.GitHub.writeCalls) != 0 {
+		t.Fatalf("github writes = %#v, want none", deps.GitHub.writeCalls)
+	}
+	text := out.String()
+	for _, want := range []string{
+		"parsevkctl labels bootstrap",
+		"Mode: dry-run",
+		"Existing labels:",
+		"- type:feature",
+		"Would create labels:",
+		"- service:parsevkctl",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestLabelsBootstrapCreatesMissingAndSkipsExisting(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.allowWrites = true
+	deps.GitHub.labels = []github.Label{{Name: "type:feature"}, {Name: "risk:low"}}
+
+	var out bytes.Buffer
+	exit := RunLabelsBootstrap(context.Background(), LabelsBootstrapRunInput{
+		GitHub: deps.GitHub,
+		Stdout: &out,
+	})
+
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; output=%s", exit, out.String())
+	}
+	if calls := countCalls(deps.GitHub.writeCalls, "CreateLabel"); calls != 26 {
+		t.Fatalf("CreateLabel calls = %d, want 26; calls=%#v", calls, deps.GitHub.writeCalls)
+	}
+	for _, created := range deps.GitHub.createdLabels {
+		if created.Name == "type:feature" || created.Name == "risk:low" {
+			t.Fatalf("created existing label: %#v", created)
+		}
+	}
+	text := out.String()
+	for _, want := range []string{
+		"Created labels:",
+		"- service:parsevkctl",
+		"Existing labels:",
+		"- type:feature",
+		"- risk:low",
+		"Failed labels: none",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestLabelsBootstrapReturnsFailureWhenCreateFails(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.allowWrites = true
+	deps.GitHub.createLabelErr = errors.New("permission denied")
+
+	var out bytes.Buffer
+	exit := RunLabelsBootstrap(context.Background(), LabelsBootstrapRunInput{
+		GitHub: deps.GitHub,
+		Stdout: &out,
+	})
+
+	if exit == 0 {
+		t.Fatalf("exit = 0, want failure")
+	}
+	if !strings.Contains(out.String(), "Failed labels:") || !strings.Contains(out.String(), "permission denied") {
+		t.Fatalf("output missing failed label summary:\n%s", out.String())
+	}
+}
+
+func TestLabelsBootstrapTreatsCreateAlreadyExistsAsExisting(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.allowWrites = true
+	deps.GitHub.createLabelErr = github.ErrLabelAlreadyExists
+
+	var out bytes.Buffer
+	exit := RunLabelsBootstrap(context.Background(), LabelsBootstrapRunInput{
+		GitHub: deps.GitHub,
+		Stdout: &out,
+	})
+
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; output=%s", exit, out.String())
+	}
+	if !strings.Contains(out.String(), "Existing labels:") || !strings.Contains(out.String(), "Failed labels: none") {
+		t.Fatalf("unexpected output:\n%s", out.String())
+	}
+}
+
+func TestLabelsBootstrapJSONDryRun(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.labels = []github.Label{{Name: "type:feature"}}
+
+	var out bytes.Buffer
+	exit := RunLabelsBootstrap(context.Background(), LabelsBootstrapRunInput{
+		GitHub: deps.GitHub,
+		DryRun: true,
+		JSON:   true,
+		Stdout: &out,
+	})
+
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0", exit)
+	}
+	if !strings.Contains(out.String(), `"dryRun": true`) || !strings.Contains(out.String(), `"wouldCreate"`) {
+		t.Fatalf("unexpected JSON output:\n%s", out.String())
+	}
+}
+
+func TestLabelNamesPreserveStandardOrder(t *testing.T) {
+	got := labelNames(github.StandardLabels()[:3])
+	want := []string{"type:feature", "type:bug", "type:infra"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("names = %#v, want %#v", got, want)
+	}
+}
+
+func countCalls(calls []string, name string) int {
+	count := 0
+	for _, call := range calls {
+		if call == name {
+			count++
+		}
+	}
+	return count
+}

--- a/tools/parsevkctl-go/internal/github/errors.go
+++ b/tools/parsevkctl-go/internal/github/errors.go
@@ -7,6 +7,7 @@ import (
 )
 
 var ErrProjectNotImplemented = errors.New("github project operations are not implemented")
+var ErrLabelAlreadyExists = errors.New("github label already exists")
 
 type CommandError struct {
 	Operation string

--- a/tools/parsevkctl-go/internal/github/github.go
+++ b/tools/parsevkctl-go/internal/github/github.go
@@ -10,6 +10,8 @@ type Adapter interface {
 	GetIssue(ctx context.Context, number int) (domain.Issue, error)
 	CreateIssue(ctx context.Context, input CreateIssueInput) (domain.Issue, error)
 	CloseIssue(ctx context.Context, number int, comment string) error
+	ListLabels(ctx context.Context) ([]Label, error)
+	CreateLabel(ctx context.Context, label Label) error
 
 	ListPullRequests(ctx context.Context, filter PullRequestFilter) ([]domain.PullRequest, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (domain.PullRequest, error)

--- a/tools/parsevkctl-go/internal/github/labels.go
+++ b/tools/parsevkctl-go/internal/github/labels.go
@@ -1,0 +1,44 @@
+package github
+
+type Label struct {
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+func StandardLabels() []Label {
+	return []Label{
+		{Name: "type:feature", Color: "1f883d", Description: "Feature work"},
+		{Name: "type:bug", Color: "d1242f", Description: "Bug fix"},
+		{Name: "type:infra", Color: "8250df", Description: "Infrastructure or tooling work"},
+		{Name: "type:docs", Color: "0969da", Description: "Documentation work"},
+		{Name: "type:test", Color: "1a7f37", Description: "Test-only work"},
+		{Name: "type:refactor", Color: "bf8700", Description: "Refactoring without behavior changes"},
+		{Name: "type:migration", Color: "953800", Description: "Migration work"},
+
+		{Name: "service:api-gateway", Color: "54aeff", Description: "API gateway service area"},
+		{Name: "service:identity-service", Color: "54aeff", Description: "Identity service area"},
+		{Name: "service:tasks-service", Color: "54aeff", Description: "Tasks service area"},
+		{Name: "service:vk-service", Color: "54aeff", Description: "VK service area"},
+		{Name: "service:telegram-service", Color: "54aeff", Description: "Telegram service area"},
+		{Name: "service:content-service", Color: "54aeff", Description: "Content service area"},
+		{Name: "service:frontend", Color: "54aeff", Description: "Frontend service area"},
+		{Name: "service:parsevkctl", Color: "54aeff", Description: "parsevkctl CLI area"},
+
+		{Name: "risk:low", Color: "2da44e", Description: "Low risk change"},
+		{Name: "risk:medium", Color: "bf8700", Description: "Medium risk change"},
+		{Name: "risk:high", Color: "bc4c00", Description: "High risk change"},
+		{Name: "risk:critical", Color: "cf222e", Description: "Critical risk change"},
+
+		{Name: "ai:ready", Color: "a2eeef", Description: "Ready for AI agent work"},
+		{Name: "ai:in-progress", Color: "a2eeef", Description: "AI agent work in progress"},
+		{Name: "ai:needs-review", Color: "a2eeef", Description: "AI output needs review"},
+		{Name: "ai:handoff-required", Color: "a2eeef", Description: "AI agent handoff required"},
+		{Name: "ai:bad-output", Color: "a2eeef", Description: "AI output rejected or unusable"},
+		{Name: "ai:approved", Color: "a2eeef", Description: "AI output approved"},
+
+		{Name: "review:passed", Color: "0e8a16", Description: "Review passed"},
+		{Name: "review:failed", Color: "b60205", Description: "Review failed"},
+		{Name: "review:changes-requested", Color: "d93f0b", Description: "Review requested changes"},
+	}
+}

--- a/tools/parsevkctl-go/internal/github/labels_test.go
+++ b/tools/parsevkctl-go/internal/github/labels_test.go
@@ -1,0 +1,35 @@
+package github
+
+import "testing"
+
+func TestStandardLabelsAreUniqueAndComplete(t *testing.T) {
+	t.Parallel()
+
+	labels := StandardLabels()
+	if len(labels) != 28 {
+		t.Fatalf("label count = %d, want 28", len(labels))
+	}
+
+	seen := map[string]bool{}
+	for _, label := range labels {
+		if label.Name == "" || label.Color == "" || label.Description == "" {
+			t.Fatalf("label must include name, color and description: %#v", label)
+		}
+		if seen[label.Name] {
+			t.Fatalf("duplicate label %q", label.Name)
+		}
+		seen[label.Name] = true
+	}
+
+	for _, name := range []string{
+		"type:feature",
+		"service:parsevkctl",
+		"risk:critical",
+		"ai:needs-review",
+		"review:changes-requested",
+	} {
+		if !seen[name] {
+			t.Fatalf("missing standard label %q", name)
+		}
+	}
+}

--- a/tools/parsevkctl-go/internal/github/shell.go
+++ b/tools/parsevkctl-go/internal/github/shell.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -101,6 +102,39 @@ func (adapter *ShellAdapter) CloseIssue(ctx context.Context, number int, comment
 	}
 
 	_, err := adapter.runGH(ctx, "close issue", args...)
+	return err
+}
+
+func (adapter *ShellAdapter) ListLabels(ctx context.Context) ([]Label, error) {
+	result, err := adapter.runGH(ctx, "list labels", "label", "list", "--limit", "200", "--json", "name,color,description")
+	if err != nil {
+		return nil, err
+	}
+
+	var labels []Label
+	if err := json.Unmarshal([]byte(result.stdout), &labels); err != nil {
+		return nil, fmt.Errorf("parse labels JSON: %w", err)
+	}
+	return labels, nil
+}
+
+func (adapter *ShellAdapter) CreateLabel(ctx context.Context, label Label) error {
+	if strings.TrimSpace(label.Name) == "" {
+		return fmt.Errorf("label name must not be empty")
+	}
+	if strings.TrimSpace(label.Color) == "" {
+		return fmt.Errorf("label color must not be empty")
+	}
+
+	args := []string{"label", "create", label.Name, "--color", label.Color}
+	if strings.TrimSpace(label.Description) != "" {
+		args = append(args, "--description", label.Description)
+	}
+
+	_, err := adapter.runGH(ctx, "create label", args...)
+	if isLabelAlreadyExistsError(err) {
+		return ErrLabelAlreadyExists
+	}
 	return err
 }
 
@@ -366,6 +400,19 @@ func (adapter *ShellAdapter) runGH(ctx context.Context, operation string, args .
 	}
 
 	return result, nil
+}
+
+func isLabelAlreadyExistsError(err error) bool {
+	var commandErr CommandError
+	if !errors.As(err, &commandErr) {
+		return false
+	}
+
+	text := strings.ToLower(commandErr.Stderr + " " + commandErr.Stdout)
+	if commandErr.Err != nil {
+		text += " " + strings.ToLower(commandErr.Err.Error())
+	}
+	return strings.Contains(text, "already exists")
 }
 
 func (adapter *ShellAdapter) validateProjectConfig() error {

--- a/tools/parsevkctl-go/internal/github/shell_test.go
+++ b/tools/parsevkctl-go/internal/github/shell_test.go
@@ -265,6 +265,47 @@ func TestCreateIssueRunsCreateThenView(t *testing.T) {
 	}
 }
 
+func TestCreateLabelMapsAlreadyExistsError(t *testing.T) {
+	t.Parallel()
+
+	adapter := newShellAdapterWithRunner(func(context.Context, string, ...string) (commandResult, error) {
+		return commandResult{stderr: "label with this name already exists"}, fakeExitError{code: 1}
+	})
+
+	err := adapter.CreateLabel(context.Background(), Label{Name: "type:feature", Color: "1f883d"})
+	if !errors.Is(err, ErrLabelAlreadyExists) {
+		t.Fatalf("CreateLabel error = %v, want ErrLabelAlreadyExists", err)
+	}
+}
+
+func TestLabelCommandArguments(t *testing.T) {
+	t.Parallel()
+
+	var got [][]string
+	adapter := newShellAdapterWithRunner(func(_ context.Context, _ string, args ...string) (commandResult, error) {
+		got = append(got, append([]string(nil), args...))
+		if len(args) >= 2 && args[0] == "label" && args[1] == "list" {
+			return commandResult{stdout: `[{"name":"type:feature","color":"1f883d","description":"Feature work"}]`}, nil
+		}
+		return commandResult{}, nil
+	})
+
+	if _, err := adapter.ListLabels(context.Background()); err != nil {
+		t.Fatalf("ListLabels returned error: %v", err)
+	}
+	if err := adapter.CreateLabel(context.Background(), Label{Name: "type:feature", Color: "1f883d", Description: "Feature work"}); err != nil {
+		t.Fatalf("CreateLabel returned error: %v", err)
+	}
+
+	want := [][]string{
+		{"label", "list", "--limit", "200", "--json", "name,color,description"},
+		{"label", "create", "type:feature", "--color", "1f883d", "--description", "Feature work"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+}
+
 func TestCreatePullRequestRunsCreateThenView(t *testing.T) {
 	t.Parallel()
 

--- a/tools/parsevkctl-go/internal/planner/executor_test.go
+++ b/tools/parsevkctl-go/internal/planner/executor_test.go
@@ -220,6 +220,10 @@ func (f *fakeGitHubAdapter) CreateIssue(context.Context, github.CreateIssueInput
 
 func (f *fakeGitHubAdapter) CloseIssue(context.Context, int, string) error { return nil }
 
+func (f *fakeGitHubAdapter) ListLabels(context.Context) ([]github.Label, error) { return nil, nil }
+
+func (f *fakeGitHubAdapter) CreateLabel(context.Context, github.Label) error { return nil }
+
 func (f *fakeGitHubAdapter) ListPullRequests(context.Context, github.PullRequestFilter) ([]domain.PullRequest, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Closes #187

## Summary
- Added `parsevkctl labels bootstrap` and global `--dry-run` support for the labels workflow.
- Centralized standard label definitions with name, color, and description.
- Added `gh label list/create` adapter methods with idempotent already-exists handling.
- Covered label definitions, dry-run behavior, creation behavior, and shell argument mapping with Go tests.

## Validation
- [x] go fmt ./...
- [x] go test ./...
- [x] go run ./cmd/parsevkctl labels bootstrap --dry-run