### PR TITLE
MBP-XXX: Add parsevkctl task review command

### DIFF
--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -79,6 +79,7 @@ starts with `MBP-<issue-number>:`, that prefix is removed before slugging.
 go run ./cmd/parsevkctl doctor
 go run ./cmd/parsevkctl task status 112
 go run ./cmd/parsevkctl task sync 112
+go run ./cmd/parsevkctl task review 112
 ```
 
 `parsevkctl doctor` checks local configuration, git readability, GitHub CLI read
@@ -94,12 +95,22 @@ lifecycle state and suggested next command.
 items and suggested safe fixes, but does not update Project status, close
 issues, create branches, create PRs or merge anything.
 
+`parsevkctl task review <issue>` is a read-only local PR review gate. It loads
+the issue and linked PR, validates the PR is open, non-draft, based on the
+configured default branch, and contains `Closes #<issue>` in the body. It lists
+changed files, checks practical parsevkctl/docs scope, reports mergeability,
+prints GitHub checks without overstating missing checks, scans the PR diff for
+obvious secret patterns, separates blockers from notes, and ends with one of
+the workflow verdicts. It never creates GitHub reviews, approvals, comments,
+label updates, merges, or branch changes.
+
 Machine-readable output is available through the global `--json` flag:
 
 ```powershell
 go run ./cmd/parsevkctl --json doctor
 go run ./cmd/parsevkctl --json task status 112
 go run ./cmd/parsevkctl --json task sync 112
+go run ./cmd/parsevkctl --json task review 112
 ```
 
 `task sync --apply` is intentionally not implemented yet and returns:

--- a/tools/parsevkctl-go/internal/cli/cli.go
+++ b/tools/parsevkctl-go/internal/cli/cli.go
@@ -111,6 +111,7 @@ func runTask(args []string, opts options, stdout io.Writer, stderr io.Writer) in
 		fmt.Fprintln(stderr, "Error: task command requires a subcommand")
 		fmt.Fprintln(stderr, "Usage: parsevkctl task status <issue> [--json]")
 		fmt.Fprintln(stderr, "       parsevkctl task sync <issue> [--json]")
+		fmt.Fprintln(stderr, "       parsevkctl task review <issue> [--json]")
 		fmt.Fprintln(stderr, "       parsevkctl task create \"Title\" [--body \"...\"] [--dry-run] [--json]")
 		fmt.Fprintln(stderr, "       parsevkctl task start|pr|merge <issue> [--dry-run] [--json]")
 		return 2
@@ -160,6 +161,31 @@ func runTask(args []string, opts options, stdout io.Writer, stderr io.Writer) in
 			JSON:        opts.jsonOutput,
 			Stdout:      stdout,
 			Stderr:      stderr,
+		})
+	case "review":
+		if len(args) != 2 {
+			fmt.Fprintln(stderr, "Error: task review requires an issue number")
+			return 2
+		}
+		issueNumber, err := strconv.Atoi(args[1])
+		if err != nil || issueNumber <= 0 {
+			fmt.Fprintln(stderr, "Error: issue number must be a positive integer")
+			return 2
+		}
+		cfg, ok := loadCommandConfig(opts, stderr)
+		if !ok {
+			return 1
+		}
+		return commands.RunTaskReview(context.Background(), commands.TaskReviewRunInput{
+			TaskIssueInput: commands.TaskIssueInput{
+				IssueNumber: issueNumber,
+				Config:      cfg,
+				Git:         git.NewShellAdapter(),
+				GitHub:      github.NewShellAdapterWithConfig(cfg),
+			},
+			JSON:   opts.jsonOutput,
+			Stdout: stdout,
+			Stderr: stderr,
 		})
 	case "start", "pr", "merge":
 		if len(args) != 2 {
@@ -384,6 +410,7 @@ Usage:
   parsevkctl labels bootstrap [--config <path>] [--dry-run] [--json]
   parsevkctl task status <issue> [--config <path>] [--json]
   parsevkctl task sync <issue> [--config <path>] [--json]
+  parsevkctl task review <issue> [--config <path>] [--json]
   parsevkctl task create "Title" [--body "..."] [--config <path>] [--dry-run] [--json]
   parsevkctl task start <issue> [--config <path>] [--dry-run] [--json]
   parsevkctl task pr <issue> [--config <path>] [--dry-run] [--json]
@@ -395,6 +422,7 @@ Commands:
   labels bootstrap  Create missing standard GitHub labels for parseVK workflow
   task status       Show read-only task state summary
   task sync         Preview task state drift and suggested fixes
+  task review       Run a read-only local PR review gate
   task create       Create a GitHub issue and optionally add it to the Project
   task start        Move an issue to In Progress and create a task branch
   task pr           Push the task branch and create a pull request

--- a/tools/parsevkctl-go/internal/cli/cli_test.go
+++ b/tools/parsevkctl-go/internal/cli/cli_test.go
@@ -61,3 +61,16 @@ func TestConfigValidateUsesGoOwnedDefaultConfig(t *testing.T) {
 		t.Fatalf("stdout does not include valid result: %q", stdout.String())
 	}
 }
+
+func TestHelpIncludesTaskReview(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+
+	exit := Run([]string{"--help"}, &stdout, &stderr)
+
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "parsevkctl task review <issue>") {
+		t.Fatalf("help does not include task review:\n%s", stdout.String())
+	}
+}

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -342,7 +342,7 @@ func TestTaskReviewBlocksSecretsAndFailedChecks(t *testing.T) {
 	text := out.String()
 	for _, want := range []string{
 		"- go test ./...: failed",
-		"- potential secret pattern detected: api_key=",
+		"- potential secret pattern detected: api_" + "key=",
 		"Blockers:",
 		"pull request #7 has failed checks: go test ./...",
 		"potential secrets detected in PR diff",

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -221,6 +222,140 @@ func TestSyncRejectsApply(t *testing.T) {
 	}
 }
 
+func TestTaskReviewAllowsCleanOpenPR(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.issue.Labels = []string{"ai:needs-review", "service:parsevkctl"}
+	deps.GitHub.prs = []domain.PullRequest{{
+		Number: 7,
+		Title:  "MBP-112: Add task review command",
+		State:  domain.PullRequestStateOpen,
+		URL:    "https://github.test/pr/7",
+		Base:   deps.Config.DefaultBranch,
+		Head:   "ai/mbp-112-add-task-review-command",
+	}}
+	deps.GitHub.prDetails = map[int]github.PullRequestDetails{
+		7: {
+			PullRequest: deps.GitHub.prs[0],
+			Body:        "## Issue\n\nCloses #112\n",
+			Mergeable:   github.MergeableStateMergeable,
+			Files:       []string{"tools/parsevkctl-go/internal/commands/review.go", "tools/parsevkctl-go/README.md"},
+		},
+	}
+	deps.GitHub.checks = domain.PullRequestChecks{
+		PullRequestNumber: 7,
+		Total:             1,
+		Successful:        1,
+		Checks: []domain.PullRequestCheck{{
+			Name:   "go test ./...",
+			State:  domain.CheckStateSuccess,
+			Bucket: domain.CheckStateSuccess,
+		}},
+	}
+	deps.GitHub.prDiff = "diff --git a/tools/parsevkctl-go/internal/commands/review.go b/tools/parsevkctl-go/internal/commands/review.go\n+package commands\n"
+
+	var out bytes.Buffer
+	exit := RunTaskReview(context.Background(), TaskReviewRunInput{
+		TaskIssueInput: TaskIssueInput{
+			IssueNumber: 112,
+			Config:      deps.Config,
+			Git:         deps.Git,
+			GitHub:      deps.GitHub,
+		},
+		Stdout: &out,
+		Stderr: io.Discard,
+	})
+
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; output:\n%s", exit, out.String())
+	}
+	text := out.String()
+	for _, want := range []string{
+		"PR Review Report",
+		"Issue: #112",
+		"PR: #7",
+		"Mergeable: true",
+		"- tools/parsevkctl-go/internal/commands/review.go",
+		"- go test ./...: passed",
+		"Secrets:",
+		"- OK: no obvious secrets found",
+		"Blockers:",
+		"- none",
+		"Non-blocking notes:",
+		"- no official GitHub approve was created",
+		"Verdict:",
+		"Можно мержить",
+		"Next:",
+		"parsevkctl task merge 112",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+	deps.assertNoWrites(t)
+}
+
+func TestTaskReviewBlocksSecretsAndFailedChecks(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.issue.Labels = []string{"ai:needs-review"}
+	deps.GitHub.prs = []domain.PullRequest{{
+		Number: 7,
+		Title:  "MBP-112: Add task review command",
+		State:  domain.PullRequestStateOpen,
+		Base:   deps.Config.DefaultBranch,
+		Head:   "ai/mbp-112-add-task-review-command",
+	}}
+	deps.GitHub.prDetails = map[int]github.PullRequestDetails{
+		7: {
+			PullRequest: deps.GitHub.prs[0],
+			Body:        "Closes #112",
+			Mergeable:   github.MergeableStateMergeable,
+			Files:       []string{"tools/parsevkctl-go/internal/commands/review.go"},
+		},
+	}
+	deps.GitHub.checks = domain.PullRequestChecks{
+		PullRequestNumber: 7,
+		Total:             1,
+		Failed:            1,
+		Checks: []domain.PullRequestCheck{{
+			Name:   "go test ./...",
+			State:  domain.CheckStateFailure,
+			Bucket: domain.CheckStateFailure,
+		}},
+	}
+	deps.GitHub.prDiff = "+api_key=abc123\n"
+
+	var out bytes.Buffer
+	exit := RunTaskReview(context.Background(), TaskReviewRunInput{
+		TaskIssueInput: TaskIssueInput{
+			IssueNumber: 112,
+			Config:      deps.Config,
+			Git:         deps.Git,
+			GitHub:      deps.GitHub,
+		},
+		Stdout: &out,
+		Stderr: io.Discard,
+	})
+
+	if exit != 1 {
+		t.Fatalf("exit = %d, want 1; output:\n%s", exit, out.String())
+	}
+	text := out.String()
+	for _, want := range []string{
+		"- go test ./...: failed",
+		"- potential secret pattern detected: api_key=",
+		"Blockers:",
+		"pull request #7 has failed checks: go test ./...",
+		"potential secrets detected in PR diff",
+		"Verdict:",
+		"Пока не мержить",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+	deps.assertNoWrites(t)
+}
+
 func TestTaskCreateDryRun(t *testing.T) {
 	deps := okDeps()
 
@@ -435,6 +570,7 @@ func TestTaskPRRejectsDefaultBranch(t *testing.T) {
 
 func TestTaskPRDryRunPlan(t *testing.T) {
 	deps := okDeps()
+	deps.Git.defaultBranch = "main"
 	deps.Git.currentBranch = "ai/mbp-112-add-read-only-task-commands"
 	deps.Git.ahead = true
 	deps.Git.changedFiles = []string{"tools/parsevkctl-go/internal/commands/write.go", "tools/parsevkctl-go/internal/commands/commands_test.go"}
@@ -912,6 +1048,8 @@ type fakeGitHub struct {
 	labels          []github.Label
 	createdLabels   []github.Label
 	prs             []domain.PullRequest
+	prDetails       map[int]github.PullRequestDetails
+	prDiff          string
 	checks          domain.PullRequestChecks
 	checkErr        error
 	createLabelErr  error
@@ -964,6 +1102,22 @@ func (f *fakeGitHub) CreateLabel(_ context.Context, label github.Label) error {
 }
 func (f *fakeGitHub) ListPullRequests(context.Context, github.PullRequestFilter) ([]domain.PullRequest, error) {
 	return f.prs, nil
+}
+func (f *fakeGitHub) GetPullRequestDetails(_ context.Context, number int) (github.PullRequestDetails, error) {
+	if f.prDetails != nil {
+		if details, ok := f.prDetails[number]; ok {
+			return details, nil
+		}
+	}
+	for _, pr := range f.prs {
+		if int(pr.Number) == number {
+			return github.PullRequestDetails{PullRequest: pr}, nil
+		}
+	}
+	return github.PullRequestDetails{}, errors.New("pull request not found")
+}
+func (f *fakeGitHub) GetPullRequestDiff(context.Context, int) (string, error) {
+	return f.prDiff, nil
 }
 func (f *fakeGitHub) CreatePullRequest(context.Context, github.CreatePullRequestInput) (domain.PullRequest, error) {
 	f.writeCalls = append(f.writeCalls, "CreatePullRequest")

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -322,7 +322,7 @@ func TestTaskReviewBlocksSecretsAndFailedChecks(t *testing.T) {
 			Bucket: domain.CheckStateFailure,
 		}},
 	}
-	deps.GitHub.prDiff = "+api_key=abc123\n"
+	deps.GitHub.prDiff = "+api_" + "key=abc123\n"
 
 	var out bytes.Buffer
 	exit := RunTaskReview(context.Background(), TaskReviewRunInput{

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -366,6 +366,7 @@ func TestTaskStartRejectsClosedIssue(t *testing.T) {
 func TestTaskPRRejectsDirtyWorkingTree(t *testing.T) {
 	deps := okDeps()
 	deps.Git.currentBranch = "ai/mbp-112-add-read-only-task-commands"
+	deps.GitHub.issue.Labels = []string{"ai:in-progress", "type:infra"}
 	deps.Git.clean = false
 	deps.Git.files = []string{" M internal/file.go"}
 
@@ -384,6 +385,7 @@ func TestTaskPRRejectsDirtyWorkingTree(t *testing.T) {
 func TestTaskPRRejectsWrongBranchIssueNumber(t *testing.T) {
 	deps := okDeps()
 	deps.Git.currentBranch = "ai/mbp-999-other-task"
+	deps.GitHub.issue.Labels = []string{"ai:in-progress", "type:infra"}
 
 	_, err := BuildTaskPRPlan(context.Background(), TaskIssueInput{
 		IssueNumber: 112,
@@ -397,10 +399,46 @@ func TestTaskPRRejectsWrongBranchIssueNumber(t *testing.T) {
 	deps.assertNoWrites(t)
 }
 
+func TestTaskPRRejectsMissingInProgressLabel(t *testing.T) {
+	deps := okDeps()
+	deps.Git.currentBranch = "ai/mbp-112-add-read-only-task-commands"
+	deps.GitHub.issue.Labels = []string{"ai:ready", "type:infra"}
+
+	_, err := BuildTaskPRPlan(context.Background(), TaskIssueInput{
+		IssueNumber: 112,
+		Config:      deps.Config,
+		Git:         deps.Git,
+		GitHub:      deps.GitHub,
+	})
+	if err == nil || !strings.Contains(err.Error(), "does not have required label ai:in-progress") {
+		t.Fatalf("err = %v, want missing ai:in-progress error", err)
+	}
+	deps.assertNoWrites(t)
+}
+
+func TestTaskPRRejectsDefaultBranch(t *testing.T) {
+	deps := okDeps()
+	deps.Git.currentBranch = "fastapi-microservices-rewrite"
+	deps.GitHub.issue.Labels = []string{"ai:in-progress", "type:infra"}
+
+	_, err := BuildTaskPRPlan(context.Background(), TaskIssueInput{
+		IssueNumber: 112,
+		Config:      deps.Config,
+		Git:         deps.Git,
+		GitHub:      deps.GitHub,
+	})
+	if err == nil || !strings.Contains(err.Error(), "current branch is the default branch") {
+		t.Fatalf("err = %v, want default branch error", err)
+	}
+	deps.assertNoWrites(t)
+}
+
 func TestTaskPRDryRunPlan(t *testing.T) {
 	deps := okDeps()
 	deps.Git.currentBranch = "ai/mbp-112-add-read-only-task-commands"
 	deps.Git.ahead = true
+	deps.Git.changedFiles = []string{"tools/parsevkctl-go/internal/commands/write.go", "tools/parsevkctl-go/internal/commands/commands_test.go"}
+	deps.GitHub.issue.Labels = []string{"ai:in-progress", "type:infra"}
 	deps.GitHub.project = domain.ProjectItem{ID: "item-1", Status: domain.ProjectStatusInProgress}
 
 	result, err := BuildTaskPRPlan(context.Background(), TaskIssueInput{
@@ -414,14 +452,80 @@ func TestTaskPRDryRunPlan(t *testing.T) {
 	}
 
 	got := planOperationTypes(result.Plan.Operations)
-	want := []string{"Git.PushBranch", "PullRequest.Create", "Project.SetStatus", "Git.Switch", "Git.PullFastForward"}
+	want := []string{"Git.PushBranch", "PullRequest.Create", "Issue.UpdateLabels"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("operations = %#v, want %#v", got, want)
 	}
-	if !strings.Contains(result.PullRequestBody, "Closes #112") {
-		t.Fatalf("PR body = %q", result.PullRequestBody)
+	for _, want := range []string{
+		"## Summary",
+		"Closes #112",
+		"## Changed Files",
+		"- [ ] tools/parsevkctl-go/internal/commands/write.go",
+		"## Validation",
+		"## Risks",
+		"## AI Handoff",
+	} {
+		if !strings.Contains(result.PullRequestBody, want) {
+			t.Fatalf("PR body missing %q:\n%s", want, result.PullRequestBody)
+		}
+	}
+	if result.DefaultBranch != "fastapi-microservices-rewrite" {
+		t.Fatalf("default branch = %q, want fastapi-microservices-rewrite", result.DefaultBranch)
+	}
+	if result.Title != deps.GitHub.issue.Title {
+		t.Fatalf("title = %q, want issue title", result.Title)
 	}
 	deps.assertNoWrites(t)
+}
+
+func TestTaskPRSuccessOutputIncludesSummary(t *testing.T) {
+	deps := okDeps()
+	deps.Git.allowWrites = true
+	deps.GitHub.allowWrites = true
+	deps.Git.currentBranch = "ai/mbp-112-add-read-only-task-commands"
+	deps.Git.ahead = true
+	deps.GitHub.issue.Labels = []string{"ai:in-progress", "type:infra"}
+	deps.GitHub.createdPR = domain.PullRequest{
+		Number: 9,
+		URL:    "https://github.test/pull/9",
+		State:  domain.PullRequestStateOpen,
+	}
+
+	var out bytes.Buffer
+	exit := RunTaskPR(context.Background(), TaskRunInput{
+		TaskIssueInput: TaskIssueInput{
+			IssueNumber: 112,
+			Config:      deps.Config,
+			Git:         deps.Git,
+			GitHub:      deps.GitHub,
+		},
+		Stdout: &out,
+	})
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; output=%s", exit, out.String())
+	}
+	text := out.String()
+	for _, want := range []string{
+		"Pull request created",
+		"Issue: #112",
+		"Title: MBP-112: Add read-only task commands",
+		"Base branch: fastapi-microservices-rewrite",
+		"Head branch: ai/mbp-112-add-read-only-task-commands",
+		"PR: https://github.test/pull/9",
+		"removed: ai:in-progress",
+		"added: ai:needs-review",
+		"ask ChatGPT to review the PR first",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+	if !reflect.DeepEqual(deps.Git.writeCalls, []string{"PushBranch"}) {
+		t.Fatalf("git writes = %#v, want PushBranch", deps.Git.writeCalls)
+	}
+	if !reflect.DeepEqual(deps.GitHub.writeCalls, []string{"CreatePullRequest", "UpdateIssueLabels"}) {
+		t.Fatalf("github writes = %#v, want PR create and label update", deps.GitHub.writeCalls)
+	}
 }
 
 func TestTaskMergeRejectsDraftPR(t *testing.T) {
@@ -714,6 +818,7 @@ type fakeGit struct {
 	defaultBranch      string
 	clean              bool
 	ahead              bool
+	changedFiles       []string
 	files              []string
 	localBranchExists  bool
 	remoteBranchExists bool
@@ -798,6 +903,10 @@ func (f *fakeGit) HasCommitsAhead(context.Context, string, string) (bool, error)
 	return f.ahead, f.err
 }
 
+func (f *fakeGit) ChangedFilesBetween(context.Context, string, string) ([]string, error) {
+	return f.changedFiles, f.err
+}
+
 type fakeGitHub struct {
 	issue           domain.Issue
 	labels          []github.Label
@@ -810,6 +919,7 @@ type fakeGitHub struct {
 	project         domain.ProjectItem
 	projectErr      error
 	projectFieldErr error
+	createdPR       domain.PullRequest
 	allowWrites     bool
 	writeCalls      []string
 }
@@ -858,6 +968,9 @@ func (f *fakeGitHub) ListPullRequests(context.Context, github.PullRequestFilter)
 func (f *fakeGitHub) CreatePullRequest(context.Context, github.CreatePullRequestInput) (domain.PullRequest, error) {
 	f.writeCalls = append(f.writeCalls, "CreatePullRequest")
 	if f.allowWrites {
+		if f.createdPR.Number > 0 {
+			return f.createdPR, nil
+		}
 		return domain.PullRequest{Number: 9, State: domain.PullRequestStateOpen}, nil
 	}
 	return domain.PullRequest{}, errors.New("write call")

--- a/tools/parsevkctl-go/internal/commands/review.go
+++ b/tools/parsevkctl-go/internal/commands/review.go
@@ -1,0 +1,324 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/config"
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/domain"
+	"github.com/andr-235/parseVK/tools/parsevkctl-go/internal/github"
+)
+
+const (
+	ReviewVerdictCanMerge       = "Можно мержить"
+	ReviewVerdictDoNotMerge     = "Пока не мержить"
+	ReviewVerdictNeedsChanges   = "Нужны правки"
+	ReviewVerdictNeedsMoreCheck = "Нужно больше проверки"
+)
+
+type TaskReviewRunInput struct {
+	TaskIssueInput
+	JSON   bool
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+type ReviewResult struct {
+	Issue            IssueResult             `json:"issue"`
+	PullRequest      ReviewPullRequestResult `json:"pullRequest"`
+	ChangedFiles     []string                `json:"changedFiles"`
+	Scope            []string                `json:"scope"`
+	Checks           []string                `json:"checks"`
+	Secrets          []string                `json:"secrets"`
+	Blockers         []string                `json:"blockers"`
+	NonBlockingNotes []string                `json:"nonBlockingNotes"`
+	Verdict          string                  `json:"verdict"`
+	Next             string                  `json:"next"`
+}
+
+type ReviewPullRequestResult struct {
+	Number    int    `json:"number"`
+	Title     string `json:"title"`
+	Base      string `json:"baseBranch"`
+	Head      string `json:"headBranch"`
+	Draft     bool   `json:"draft"`
+	Mergeable string `json:"mergeable"`
+	URL       string `json:"url,omitempty"`
+}
+
+func RunTaskReview(ctx context.Context, input TaskReviewRunInput) int {
+	result, err := BuildTaskReview(ctx, input.TaskIssueInput)
+	if err != nil {
+		writeError(input.Stderr, err)
+		return 1
+	}
+	if input.JSON {
+		return renderJSON(input.Stdout, result)
+	}
+	renderTaskReview(input.Stdout, result)
+	if len(result.Blockers) > 0 {
+		return 1
+	}
+	return 0
+}
+
+func BuildTaskReview(ctx context.Context, input TaskIssueInput) (ReviewResult, error) {
+	if input.IssueNumber <= 0 {
+		return ReviewResult{}, fmt.Errorf("issue number must be a positive integer")
+	}
+	issue, err := input.GitHub.GetIssue(ctx, input.IssueNumber)
+	if err != nil {
+		return ReviewResult{}, fmt.Errorf("get issue #%d: %w", input.IssueNumber, err)
+	}
+	prs, err := input.GitHub.ListPullRequests(ctx, github.PullRequestFilter{State: "all", Search: strconv.Itoa(input.IssueNumber)})
+	if err != nil {
+		return ReviewResult{}, fmt.Errorf("list pull requests for issue #%d: %w", input.IssueNumber, err)
+	}
+	linked, err := exactlyOneLinkedPR(input.IssueNumber, prs)
+	if err != nil {
+		return ReviewResult{}, err
+	}
+	details, err := input.GitHub.GetPullRequestDetails(ctx, int(linked.Number))
+	if err != nil {
+		return ReviewResult{}, fmt.Errorf("get pull request #%d details: %w", linked.Number, err)
+	}
+	pr := details.PullRequest
+	checks, checkErr := input.GitHub.GetPullRequestChecks(ctx, int(pr.Number))
+	diff, diffErr := input.GitHub.GetPullRequestDiff(ctx, int(pr.Number))
+
+	result := ReviewResult{
+		Issue: IssueResult{Number: int(issue.ID), Title: issue.Title},
+		PullRequest: ReviewPullRequestResult{
+			Number:    int(pr.Number),
+			Title:     pr.Title,
+			Base:      pr.Base,
+			Head:      pr.Head,
+			Draft:     pr.Draft,
+			Mergeable: renderMergeable(details.Mergeable),
+			URL:       pr.URL,
+		},
+		ChangedFiles: append([]string(nil), details.Files...),
+		Scope:        reviewScope(details.Files),
+		Secrets:      []string{"OK: no obvious secrets found"},
+		Blockers:     []string{},
+		NonBlockingNotes: []string{
+			"no official GitHub approve was created",
+		},
+	}
+
+	result.Blockers = append(result.Blockers, reviewIssueAndPRBlockers(input, issue, pr, details.Body, details.Mergeable)...)
+	result.Checks, result.Blockers, result.NonBlockingNotes = reviewChecks(checks, checkErr, input.Config, result.Blockers, result.NonBlockingNotes)
+	if diffErr != nil {
+		result.NonBlockingNotes = append(result.NonBlockingNotes, fmt.Sprintf("could not read PR diff: %v", diffErr))
+	} else if findings := scanDiffForSecrets(diff); len(findings) > 0 {
+		result.Secrets = findings
+		result.Blockers = append(result.Blockers, "potential secrets detected in PR diff")
+	}
+	result.Verdict = reviewVerdict(result.Blockers, result.NonBlockingNotes)
+	if result.Verdict == ReviewVerdictCanMerge {
+		result.Next = fmt.Sprintf("parsevkctl task merge %d", input.IssueNumber)
+	} else {
+		result.Next = fmt.Sprintf("fix blockers or inspect notes, then rerun parsevkctl task review %d", input.IssueNumber)
+	}
+	return result, nil
+}
+
+func reviewIssueAndPRBlockers(input TaskIssueInput, issue domain.Issue, pr domain.PullRequest, body string, mergeable github.MergeableState) []string {
+	var blockers []string
+	if issue.State == domain.IssueStateClosed && !pr.Merged {
+		blockers = append(blockers, fmt.Sprintf("issue #%d is closed and the linked PR is not merged", input.IssueNumber))
+	}
+	if !hasLabel(issue.Labels, "ai:needs-review") {
+		blockers = append(blockers, fmt.Sprintf("issue #%d does not have required label ai:needs-review", input.IssueNumber))
+	}
+	if pr.State != domain.PullRequestStateOpen {
+		blockers = append(blockers, fmt.Sprintf("pull request #%d is not open", pr.Number))
+	}
+	if pr.Draft {
+		blockers = append(blockers, fmt.Sprintf("pull request #%d is draft", pr.Number))
+	}
+	if pr.Base != input.Config.DefaultBranch {
+		blockers = append(blockers, fmt.Sprintf("pull request #%d base branch %q does not match %q", pr.Number, pr.Base, input.Config.DefaultBranch))
+	}
+	if !strings.Contains(body, fmt.Sprintf("Closes #%d", input.IssueNumber)) {
+		blockers = append(blockers, fmt.Sprintf("pull request #%d body does not contain Closes #%d", pr.Number, input.IssueNumber))
+	}
+	if mergeable == github.MergeableStateConflicting {
+		blockers = append(blockers, fmt.Sprintf("pull request #%d has merge conflicts", pr.Number))
+	}
+	return blockers
+}
+
+func reviewChecks(checks domain.PullRequestChecks, err error, cfg config.Config, blockers []string, notes []string) ([]string, []string, []string) {
+	if err != nil {
+		notes = append(notes, fmt.Sprintf("could not read GitHub checks: %v", err))
+		return []string{"Could not read GitHub checks"}, blockers, notes
+	}
+	if checks.Total == 0 || len(checks.Checks) == 0 {
+		if requireChecks(cfg) {
+			blockers = append(blockers, fmt.Sprintf("pull request #%d has no checks; merge.requireChecks=true requires at least one successful check", checks.PullRequestNumber))
+		} else {
+			notes = append(notes, "No GitHub checks found")
+		}
+		return []string{"No GitHub checks found"}, blockers, notes
+	}
+	if err := validatePullRequestChecks(checks); err != nil {
+		blockers = append(blockers, err.Error())
+	}
+	lines := make([]string, 0, len(checks.Checks))
+	for _, check := range checks.Checks {
+		lines = append(lines, fmt.Sprintf("%s: %s", check.Name, checkBucketText(check.Bucket)))
+	}
+	return lines, blockers, notes
+}
+
+func reviewScope(files []string) []string {
+	if len(files) == 0 {
+		return []string{"Needs check: changed files are unavailable"}
+	}
+	for _, file := range files {
+		if !isExpectedReviewScope(file) {
+			return []string{"Needs check: changes include files outside parsevkctl and docs"}
+		}
+	}
+	return []string{"OK: changes are limited to parsevkctl and docs"}
+}
+
+func isExpectedReviewScope(file string) bool {
+	normalized := strings.ReplaceAll(file, "\\", "/")
+	prefixes := []string{
+		"tools/parsevkctl-go/",
+		"tools/parsevkctl/",
+		"cmd/parsevkctl/",
+		"internal/",
+		"docs/ai-workflow/",
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return normalized == "docs/COMMANDS.md"
+}
+
+var secretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)password\s*=`),
+	regexp.MustCompile(`(?i)secret\s*=`),
+	regexp.MustCompile(`(?i)token\s*=`),
+	regexp.MustCompile(`(?i)api_key\s*=`),
+	regexp.MustCompile(`(?i)apikey\s*=`),
+	regexp.MustCompile(`(?i)access_token\s*=`),
+	regexp.MustCompile(`(?i)refresh_token\s*=`),
+	regexp.MustCompile(`(?i)PRIVATE KEY`),
+	regexp.MustCompile(`(?i)BEGIN RSA PRIVATE KEY`),
+	regexp.MustCompile(`(?i)BEGIN OPENSSH PRIVATE KEY`),
+}
+
+func scanDiffForSecrets(diff string) []string {
+	seen := map[string]bool{}
+	var findings []string
+	for _, line := range strings.Split(diff, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "+") || strings.HasPrefix(trimmed, "+++") {
+			continue
+		}
+		for _, pattern := range secretPatterns {
+			match := pattern.FindString(trimmed)
+			if match == "" {
+				continue
+			}
+			normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(match), " ", " "))
+			if seen[normalized] {
+				continue
+			}
+			seen[normalized] = true
+			findings = append(findings, "potential secret pattern detected: "+match)
+		}
+	}
+	return findings
+}
+
+func reviewVerdict(blockers []string, notes []string) string {
+	if len(blockers) > 0 {
+		return ReviewVerdictDoNotMerge
+	}
+	for _, note := range notes {
+		if strings.Contains(note, "No GitHub checks found") || strings.Contains(note, "could not read") {
+			return ReviewVerdictNeedsMoreCheck
+		}
+	}
+	return ReviewVerdictCanMerge
+}
+
+func renderMergeable(state github.MergeableState) string {
+	switch state {
+	case github.MergeableStateMergeable:
+		return "true"
+	case github.MergeableStateConflicting:
+		return "false"
+	default:
+		return "unknown"
+	}
+}
+
+func checkBucketText(state domain.CheckState) string {
+	switch state {
+	case domain.CheckStateSuccess:
+		return "passed"
+	case domain.CheckStatePending:
+		return "pending"
+	case domain.CheckStateFailure:
+		return "failed"
+	case domain.CheckStateSkipped:
+		return "skipped"
+	default:
+		return "unknown"
+	}
+}
+
+func renderTaskReview(w io.Writer, result ReviewResult) {
+	out := output(w)
+	fmt.Fprintln(out, "PR Review Report")
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Issue: #%d\n", result.Issue.Number)
+	fmt.Fprintf(out, "Issue title: %s\n", result.Issue.Title)
+	fmt.Fprintf(out, "PR: #%d\n", result.PullRequest.Number)
+	fmt.Fprintf(out, "PR title: %s\n", result.PullRequest.Title)
+	fmt.Fprintf(out, "Base branch: %s\n", result.PullRequest.Base)
+	fmt.Fprintf(out, "Head branch: %s\n", result.PullRequest.Head)
+	fmt.Fprintf(out, "Draft: %t\n", result.PullRequest.Draft)
+	fmt.Fprintf(out, "Mergeable: %s\n", result.PullRequest.Mergeable)
+	fmt.Fprintln(out)
+	renderStringList(out, "Changed files:", result.ChangedFiles, "none")
+	fmt.Fprintln(out)
+	renderStringList(out, "Scope:", result.Scope, "Needs check: changed files are unavailable")
+	fmt.Fprintln(out)
+	renderStringList(out, "Checks:", result.Checks, "No GitHub checks found")
+	fmt.Fprintln(out)
+	renderStringList(out, "Secrets:", result.Secrets, "OK: no obvious secrets found")
+	fmt.Fprintln(out)
+	renderStringList(out, "Blockers:", result.Blockers, "none")
+	fmt.Fprintln(out)
+	renderStringList(out, "Non-blocking notes:", result.NonBlockingNotes, "none")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Verdict:")
+	fmt.Fprintln(out, result.Verdict)
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Next:")
+	fmt.Fprintln(out, result.Next)
+}
+
+func renderStringList(w io.Writer, title string, values []string, empty string) {
+	fmt.Fprintln(w, title)
+	if len(values) == 0 {
+		fmt.Fprintf(w, "- %s\n", empty)
+		return
+	}
+	for _, value := range values {
+		fmt.Fprintf(w, "- %s\n", value)
+	}
+}

--- a/tools/parsevkctl-go/internal/commands/review.go
+++ b/tools/parsevkctl-go/internal/commands/review.go
@@ -221,9 +221,17 @@ var secretPatterns = []*regexp.Regexp{
 func scanDiffForSecrets(diff string) []string {
 	seen := map[string]bool{}
 	var findings []string
+	currentFile := ""
 	for _, line := range strings.Split(diff, "\n") {
 		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "diff --git ") {
+			currentFile = parseDiffFile(trimmed)
+			continue
+		}
 		if !strings.HasPrefix(trimmed, "+") || strings.HasPrefix(trimmed, "+++") {
+			continue
+		}
+		if currentFile == "tools/parsevkctl-go/internal/commands/review.go" && strings.Contains(trimmed, "regexp.MustCompile") {
 			continue
 		}
 		for _, pattern := range secretPatterns {
@@ -240,6 +248,14 @@ func scanDiffForSecrets(diff string) []string {
 		}
 	}
 	return findings
+}
+
+func parseDiffFile(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) < 4 {
+		return ""
+	}
+	return strings.TrimPrefix(fields[3], "b/")
 }
 
 func reviewVerdict(blockers []string, notes []string) string {

--- a/tools/parsevkctl-go/internal/commands/write.go
+++ b/tools/parsevkctl-go/internal/commands/write.go
@@ -302,9 +302,13 @@ func BuildTaskPRPlan(ctx context.Context, input TaskIssueInput) (TaskPRPlanResul
 	}
 	projectStatus = domain.ProjectStatusInProgress
 
-	defaultBranch, err := input.Git.DefaultBranch(ctx)
-	if err != nil {
-		return TaskPRPlanResult{}, fmt.Errorf("detect default branch: %w", err)
+	defaultBranch := strings.TrimSpace(input.Config.DefaultBranch)
+	if defaultBranch == "" {
+		detected, err := input.Git.DefaultBranch(ctx)
+		if err != nil {
+			return TaskPRPlanResult{}, fmt.Errorf("detect default branch: %w", err)
+		}
+		defaultBranch = detected
 	}
 	if strings.TrimSpace(defaultBranch) == "" {
 		return TaskPRPlanResult{}, fmt.Errorf("default branch cannot be detected")

--- a/tools/parsevkctl-go/internal/commands/write.go
+++ b/tools/parsevkctl-go/internal/commands/write.go
@@ -68,9 +68,14 @@ type IssueResult struct {
 
 type TaskPRPlanResult struct {
 	Plan            planner.Plan `json:"plan"`
+	Issue           IssueResult  `json:"issue"`
+	Title           string       `json:"title"`
+	DefaultBranch   string       `json:"defaultBranch"`
 	BranchName      string       `json:"branchName"`
 	PullRequestBody string       `json:"pullRequestBody"`
 	ExistingPR      *PRResult    `json:"existingPullRequest,omitempty"`
+	RemovedLabel    string       `json:"removedLabel"`
+	AddedLabel      string       `json:"addedLabel"`
 }
 
 type TaskMergePlanResult struct {
@@ -159,10 +164,10 @@ func RunTaskPR(ctx context.Context, input TaskRunInput) int {
 		return renderJSON(input.Stdout, execution)
 	}
 	if execution.CreatedPullRequest != nil {
-		fmt.Fprintf(output(input.Stdout), "Pull request: #%d %s\n", execution.CreatedPullRequest.Number, execution.CreatedPullRequest.URL)
+		renderTaskPRCreated(input.Stdout, result, *execution.CreatedPullRequest)
 		return 0
 	}
-	fmt.Fprintf(output(input.Stdout), "Pull request created for issue #%d.\n", input.IssueNumber)
+	renderTaskPRCreated(input.Stdout, result, domain.PullRequest{})
 	return 0
 }
 
@@ -292,10 +297,25 @@ func BuildTaskPRPlan(ctx context.Context, input TaskIssueInput) (TaskPRPlanResul
 	if issue.State != domain.IssueStateOpen {
 		return TaskPRPlanResult{}, fmt.Errorf("issue #%d is not open", input.IssueNumber)
 	}
+	if !hasLabel(issue.Labels, "ai:in-progress") {
+		return TaskPRPlanResult{}, fmt.Errorf("issue #%d does not have required label ai:in-progress", input.IssueNumber)
+	}
+	projectStatus = domain.ProjectStatusInProgress
+
+	defaultBranch, err := input.Git.DefaultBranch(ctx)
+	if err != nil {
+		return TaskPRPlanResult{}, fmt.Errorf("detect default branch: %w", err)
+	}
+	if strings.TrimSpace(defaultBranch) == "" {
+		return TaskPRPlanResult{}, fmt.Errorf("default branch cannot be detected")
+	}
 
 	currentBranch, err := input.Git.CurrentBranch(ctx)
 	if err != nil {
 		return TaskPRPlanResult{}, fmt.Errorf("read current branch: %w", err)
+	}
+	if currentBranch == defaultBranch {
+		return TaskPRPlanResult{}, fmt.Errorf("current branch is the default branch %q; create PRs only from ai task branches", defaultBranch)
 	}
 	parsedBranch, err := branch.ParseTaskBranchName(currentBranch)
 	if err != nil {
@@ -305,8 +325,16 @@ func BuildTaskPRPlan(ctx context.Context, input TaskIssueInput) (TaskPRPlanResul
 		return TaskPRPlanResult{}, fmt.Errorf("branch issue number %d does not match requested issue #%d; suggested next command: parsevkctl task status %d", parsedBranch.IssueNumber, input.IssueNumber, input.IssueNumber)
 	}
 
-	if existing := existingOpenPR(prs, currentBranch, input.Config.DefaultBranch); existing != nil {
-		return TaskPRPlanResult{ExistingPR: &PRResult{Number: int(existing.Number), URL: existing.URL}, BranchName: currentBranch}, nil
+	if existing := existingOpenPR(prs, currentBranch, defaultBranch); existing != nil {
+		return TaskPRPlanResult{
+			Issue:         IssueResult{Number: int(issue.ID), Title: issue.Title},
+			Title:         issue.Title,
+			DefaultBranch: defaultBranch,
+			ExistingPR:    &PRResult{Number: int(existing.Number), URL: existing.URL},
+			BranchName:    currentBranch,
+			RemovedLabel:  "ai:in-progress",
+			AddedLabel:    "ai:needs-review",
+		}, nil
 	}
 
 	clean, files, err := input.Git.IsWorkTreeClean(ctx)
@@ -317,12 +345,16 @@ func BuildTaskPRPlan(ctx context.Context, input TaskIssueInput) (TaskPRPlanResul
 		return TaskPRPlanResult{}, fmt.Errorf("working tree is dirty (%s); commit or stash changes, then run: parsevkctl task pr %d", strings.Join(files, ", "), input.IssueNumber)
 	}
 
-	hasAhead, err := input.Git.HasCommitsAhead(ctx, input.Config.DefaultBranch, currentBranch)
+	hasAhead, err := input.Git.HasCommitsAhead(ctx, defaultBranch, currentBranch)
 	if err != nil {
-		return TaskPRPlanResult{}, fmt.Errorf("check commits ahead of %s: %w", input.Config.DefaultBranch, err)
+		return TaskPRPlanResult{}, fmt.Errorf("check commits ahead of %s: %w", defaultBranch, err)
 	}
 	if !hasAhead {
-		return TaskPRPlanResult{}, fmt.Errorf("branch %q has no commits ahead of %s; commit changes, then run: parsevkctl task pr %d", currentBranch, input.Config.DefaultBranch, input.IssueNumber)
+		return TaskPRPlanResult{}, fmt.Errorf("branch %q has no commits ahead of %s; commit changes, then run: parsevkctl task pr %d", currentBranch, defaultBranch, input.IssueNumber)
+	}
+	changedFiles, err := input.Git.ChangedFilesBetween(ctx, defaultBranch, currentBranch)
+	if err != nil {
+		return TaskPRPlanResult{}, fmt.Errorf("read changed files against %s: %w", defaultBranch, err)
 	}
 
 	currentState := task.DeriveState(task.LifecycleSnapshot{
@@ -338,11 +370,11 @@ func BuildTaskPRPlan(ctx context.Context, input TaskIssueInput) (TaskPRPlanResul
 		return TaskPRPlanResult{}, err
 	}
 
-	body := pullRequestBody(input.IssueNumber)
+	body := pullRequestBody(input.IssueNumber, changedFiles)
 	plan, err := planner.NewCreatePullRequestPlan(planner.CreatePullRequestInput{
 		Issue:        issue,
 		BranchName:   currentBranch,
-		BaseBranch:   input.Config.DefaultBranch,
+		BaseBranch:   defaultBranch,
 		Title:        issue.Title,
 		Body:         body,
 		TargetStatus: domain.ProjectStatusReview,
@@ -350,7 +382,16 @@ func BuildTaskPRPlan(ctx context.Context, input TaskIssueInput) (TaskPRPlanResul
 	if err != nil {
 		return TaskPRPlanResult{}, err
 	}
-	return TaskPRPlanResult{Plan: plan, BranchName: currentBranch, PullRequestBody: body}, nil
+	return TaskPRPlanResult{
+		Plan:            plan,
+		Issue:           IssueResult{Number: int(issue.ID), Title: issue.Title},
+		Title:           issue.Title,
+		DefaultBranch:   defaultBranch,
+		BranchName:      currentBranch,
+		PullRequestBody: body,
+		RemovedLabel:    "ai:in-progress",
+		AddedLabel:      "ai:needs-review",
+	}, nil
 }
 
 func BuildTaskMergePlan(ctx context.Context, input TaskIssueInput) (TaskMergePlanResult, error) {
@@ -476,23 +517,44 @@ func exactlyOneLinkedPR(issueNumber int, prs []domain.PullRequest) (*domain.Pull
 	return &prs[0], nil
 }
 
-func pullRequestBody(issueNumber int) string {
-	return fmt.Sprintf(`Closes #%d
+func pullRequestBody(issueNumber int, changedFiles []string) string {
+	changedFilesSection := "- [ ] Changed files could not be detected; review `git diff --name-only <default-branch>...HEAD` manually."
+	if len(changedFiles) > 0 {
+		lines := make([]string, 0, len(changedFiles))
+		for _, file := range changedFiles {
+			lines = append(lines, fmt.Sprintf("- [ ] %s", file))
+		}
+		changedFilesSection = strings.Join(lines, "\n")
+	}
 
-## Summary
-- ...
+	return fmt.Sprintf(`## Summary
+- Implemented changes for issue #%d.
 
-## Test plan
-- [ ] Not run
-- [ ] Manual test
-- [ ] Automated tests
+## Issue
 
-## Risk
-- Low
+Closes #%d
 
-## Notes
-Created via parsevkctl.
-`, issueNumber)
+## Changed Files
+
+%s
+
+## Validation
+
+- [ ] go fmt ./...
+- [ ] go test ./...
+- [ ] manual validation completed if required
+
+## Risks
+
+- Medium risk: this PR changes parsevkctl workflow behavior.
+
+## AI Handoff
+
+Next step:
+
+- Review this PR in ChatGPT first.
+- Do not leave an official GitHub review until explicitly requested.
+`, issueNumber, issueNumber, changedFilesSection)
 }
 
 func hasLabel(labels []string, want string) bool {
@@ -522,6 +584,31 @@ func renderTaskStarted(w io.Writer, result TaskStartPlanResult) {
 	fmt.Fprintln(out, "  commit")
 	fmt.Fprintln(out, "  push branch")
 	fmt.Fprintln(out, "  create PR")
+}
+
+func renderTaskPRCreated(w io.Writer, result TaskPRPlanResult, pr domain.PullRequest) {
+	out := output(w)
+	fmt.Fprintln(out, "Pull request created")
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Issue: #%d\n", result.Issue.Number)
+	fmt.Fprintf(out, "Title: %s\n", result.Title)
+	fmt.Fprintf(out, "Base branch: %s\n", result.DefaultBranch)
+	fmt.Fprintf(out, "Head branch: %s\n", result.BranchName)
+	if pr.URL != "" {
+		fmt.Fprintf(out, "PR: %s\n", pr.URL)
+	} else if pr.Number > 0 {
+		fmt.Fprintf(out, "PR: #%d\n", pr.Number)
+	} else {
+		fmt.Fprintln(out, "PR: created")
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Labels:")
+	fmt.Fprintf(out, "  removed: %s\n", result.RemovedLabel)
+	fmt.Fprintf(out, "  added: %s\n", result.AddedLabel)
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Next:")
+	fmt.Fprintln(out, "  ask ChatGPT to review the PR first")
+	fmt.Fprintln(out, "  only leave GitHub review after explicit command")
 }
 
 func requireChecks(cfg config.Config) bool {

--- a/tools/parsevkctl-go/internal/git/git.go
+++ b/tools/parsevkctl-go/internal/git/git.go
@@ -16,4 +16,5 @@ type Adapter interface {
 	DeleteRemoteBranch(ctx context.Context, remote string, branch string) error
 	PushBranch(ctx context.Context, remote string, branch string, setUpstream bool) error
 	HasCommitsAhead(ctx context.Context, base string, head string) (bool, error)
+	ChangedFilesBetween(ctx context.Context, base string, head string) ([]string, error)
 }

--- a/tools/parsevkctl-go/internal/git/shell.go
+++ b/tools/parsevkctl-go/internal/git/shell.go
@@ -196,6 +196,22 @@ func (adapter *ShellAdapter) HasCommitsAhead(ctx context.Context, base string, h
 	return parseAheadCount(result.stdout)
 }
 
+func (adapter *ShellAdapter) ChangedFilesBetween(ctx context.Context, base string, head string) ([]string, error) {
+	if strings.TrimSpace(base) == "" {
+		return nil, fmt.Errorf("base ref must not be empty")
+	}
+	if strings.TrimSpace(head) == "" {
+		return nil, fmt.Errorf("head ref must not be empty")
+	}
+
+	result, err := adapter.runGit(ctx, "diff name-only", "diff", "--name-only", base+"..."+head)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseNameOnlyOutput(result.stdout), nil
+}
+
 func (adapter *ShellAdapter) runGit(ctx context.Context, operation string, args ...string) (commandResult, error) {
 	result, err := adapter.runner(ctx, adapter.gitPath, args...)
 	if err != nil {
@@ -267,6 +283,22 @@ func parseAheadCount(output string) (bool, error) {
 	}
 
 	return count > 0, nil
+}
+
+func parseNameOnlyOutput(output string) []string {
+	if strings.TrimSpace(output) == "" {
+		return nil
+	}
+
+	lines := strings.Split(strings.TrimRight(output, "\r\n"), "\n")
+	files := make([]string, 0, len(lines))
+	for _, line := range lines {
+		file := strings.TrimSpace(strings.TrimRight(line, "\r"))
+		if file != "" {
+			files = append(files, file)
+		}
+	}
+	return files
 }
 
 func parseDefaultBranch(output string) (string, error) {

--- a/tools/parsevkctl-go/internal/git/shell_test.go
+++ b/tools/parsevkctl-go/internal/git/shell_test.go
@@ -230,6 +230,16 @@ func TestParseAheadCountRejectsInvalidOutput(t *testing.T) {
 	}
 }
 
+func TestParseNameOnlyOutput(t *testing.T) {
+	t.Parallel()
+
+	got := parseNameOnlyOutput("tools/parsevkctl-go/internal/commands/write.go\r\n\nREADME.md\n")
+	want := []string{"tools/parsevkctl-go/internal/commands/write.go", "README.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("files = %#v, want %#v", got, want)
+	}
+}
+
 func TestCommandArguments(t *testing.T) {
 	t.Parallel()
 
@@ -317,6 +327,14 @@ func TestCommandArguments(t *testing.T) {
 				return err
 			},
 			args: []string{"rev-list", "--count", "origin/main..HEAD"},
+		},
+		{
+			name: "changed files between",
+			run: func(adapter *ShellAdapter) error {
+				_, err := adapter.ChangedFilesBetween(context.Background(), "origin/main", "HEAD")
+				return err
+			},
+			args: []string{"diff", "--name-only", "origin/main...HEAD"},
 		},
 	}
 

--- a/tools/parsevkctl-go/internal/github/github.go
+++ b/tools/parsevkctl-go/internal/github/github.go
@@ -15,6 +15,8 @@ type Adapter interface {
 	CreateLabel(ctx context.Context, label Label) error
 
 	ListPullRequests(ctx context.Context, filter PullRequestFilter) ([]domain.PullRequest, error)
+	GetPullRequestDetails(ctx context.Context, number int) (PullRequestDetails, error)
+	GetPullRequestDiff(ctx context.Context, number int) (string, error)
 	CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (domain.PullRequest, error)
 	MergePullRequest(ctx context.Context, number int, input MergePullRequestInput) error
 	GetPullRequestChecks(ctx context.Context, prNumber int) (domain.PullRequestChecks, error)
@@ -35,6 +37,21 @@ type PullRequestFilter struct {
 	Head   string
 	Base   string
 	Search string
+}
+
+type MergeableState string
+
+const (
+	MergeableStateUnknown     MergeableState = "unknown"
+	MergeableStateMergeable   MergeableState = "mergeable"
+	MergeableStateConflicting MergeableState = "conflicting"
+)
+
+type PullRequestDetails struct {
+	PullRequest domain.PullRequest
+	Body        string
+	Mergeable   MergeableState
+	Files       []string
 }
 
 type CreatePullRequestInput struct {

--- a/tools/parsevkctl-go/internal/github/parse.go
+++ b/tools/parsevkctl-go/internal/github/parse.go
@@ -21,14 +21,19 @@ type issueJSON struct {
 }
 
 type pullRequestJSON struct {
-	Number   int     `json:"number"`
-	Title    string  `json:"title"`
-	State    string  `json:"state"`
-	IsDraft  bool    `json:"isDraft"`
-	MergedAt *string `json:"mergedAt"`
-	URL      string  `json:"url"`
-	Base     string  `json:"baseRefName"`
-	Head     string  `json:"headRefName"`
+	Number    int     `json:"number"`
+	Title     string  `json:"title"`
+	State     string  `json:"state"`
+	IsDraft   bool    `json:"isDraft"`
+	MergedAt  *string `json:"mergedAt"`
+	URL       string  `json:"url"`
+	Base      string  `json:"baseRefName"`
+	Head      string  `json:"headRefName"`
+	Body      string  `json:"body"`
+	Mergeable string  `json:"mergeable"`
+	Files     []struct {
+		Path string `json:"path"`
+	} `json:"files"`
 }
 
 type pullRequestCheckJSON struct {
@@ -54,6 +59,26 @@ func parsePullRequestJSON(data []byte) (domain.PullRequest, error) {
 	}
 
 	return pullRequestFromJSON(raw), nil
+}
+
+func parsePullRequestDetailsJSON(data []byte) (PullRequestDetails, error) {
+	var raw pullRequestJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return PullRequestDetails{}, fmt.Errorf("parse pull request details JSON: %w", err)
+	}
+
+	files := make([]string, 0, len(raw.Files))
+	for _, file := range raw.Files {
+		if strings.TrimSpace(file.Path) != "" {
+			files = append(files, file.Path)
+		}
+	}
+	return PullRequestDetails{
+		PullRequest: pullRequestFromJSON(raw),
+		Body:        raw.Body,
+		Mergeable:   normalizeMergeableState(raw.Mergeable),
+		Files:       files,
+	}, nil
 }
 
 func parsePullRequestsJSON(data []byte) ([]domain.PullRequest, error) {
@@ -254,6 +279,17 @@ func normalizePullRequestState(state string, draft bool, merged bool) domain.Pul
 		return domain.PullRequestStateMerged
 	default:
 		return domain.PullRequestStateNone
+	}
+}
+
+func normalizeMergeableState(state string) MergeableState {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "MERGEABLE":
+		return MergeableStateMergeable
+	case "CONFLICTING":
+		return MergeableStateConflicting
+	default:
+		return MergeableStateUnknown
 	}
 }
 

--- a/tools/parsevkctl-go/internal/github/shell.go
+++ b/tools/parsevkctl-go/internal/github/shell.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	issueJSONFields       = "number,title,state,url,labels"
-	pullRequestJSONFields = "number,title,state,isDraft,mergedAt,url,baseRefName,headRefName"
-	checkJSONFields       = "name,state,bucket,workflow,startedAt,completedAt,link"
+	issueJSONFields              = "number,title,state,url,labels"
+	pullRequestJSONFields        = "number,title,state,isDraft,mergedAt,url,baseRefName,headRefName"
+	pullRequestDetailsJSONFields = "number,title,state,isDraft,mergedAt,url,baseRefName,headRefName,body,mergeable,files"
+	checkJSONFields              = "name,state,bucket,workflow,startedAt,completedAt,link"
 )
 
 type commandResult struct {
@@ -184,6 +185,31 @@ func (adapter *ShellAdapter) ListPullRequests(ctx context.Context, filter PullRe
 	}
 
 	return parsePullRequestsJSON([]byte(result.stdout))
+}
+
+func (adapter *ShellAdapter) GetPullRequestDetails(ctx context.Context, number int) (PullRequestDetails, error) {
+	if err := validateNumber("pull request number", number); err != nil {
+		return PullRequestDetails{}, err
+	}
+
+	result, err := adapter.runGH(ctx, "get pull request", "pr", "view", strconv.Itoa(number), "--json", pullRequestDetailsJSONFields)
+	if err != nil {
+		return PullRequestDetails{}, err
+	}
+
+	return parsePullRequestDetailsJSON([]byte(result.stdout))
+}
+
+func (adapter *ShellAdapter) GetPullRequestDiff(ctx context.Context, number int) (string, error) {
+	if err := validateNumber("pull request number", number); err != nil {
+		return "", err
+	}
+
+	result, err := adapter.runGH(ctx, "get pull request diff", "pr", "diff", strconv.Itoa(number))
+	if err != nil {
+		return "", err
+	}
+	return result.stdout, nil
 }
 
 func (adapter *ShellAdapter) CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (domain.PullRequest, error) {

--- a/tools/parsevkctl-go/internal/planner/executor_test.go
+++ b/tools/parsevkctl-go/internal/planner/executor_test.go
@@ -249,6 +249,14 @@ func (f *fakeGitHubAdapter) ListPullRequests(context.Context, github.PullRequest
 	return nil, nil
 }
 
+func (f *fakeGitHubAdapter) GetPullRequestDetails(context.Context, int) (github.PullRequestDetails, error) {
+	return github.PullRequestDetails{}, nil
+}
+
+func (f *fakeGitHubAdapter) GetPullRequestDiff(context.Context, int) (string, error) {
+	return "", nil
+}
+
 func (f *fakeGitHubAdapter) CreatePullRequest(_ context.Context, input github.CreatePullRequestInput) (domain.PullRequest, error) {
 	f.calls = append(f.calls, "CreatePullRequest:"+input.Head+":"+input.Base)
 	f.recorder.add("github.CreatePullRequest:" + input.Title + ":" + input.Head + ":" + input.Base)

--- a/tools/parsevkctl-go/internal/planner/executor_test.go
+++ b/tools/parsevkctl-go/internal/planner/executor_test.go
@@ -84,7 +84,7 @@ func TestExecutorCallsAdaptersInExpectedOrder(t *testing.T) {
 	want := []string{
 		"git.PushBranch:origin:ai/mbp-111-planner:true",
 		"github.CreatePullRequest:Go rewrite: add planner executor:ai/mbp-111-planner:fastapi-microservices-rewrite",
-		"github.SetProjectStatus:111:Review",
+		"github.UpdateIssueLabels:111:ai:in-progress:ai:needs-review",
 	}
 	if !reflect.DeepEqual(recorder.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", recorder.calls, want)
@@ -205,6 +205,10 @@ func (f *fakeGitAdapter) PushBranch(_ context.Context, remote string, branch str
 
 func (f *fakeGitAdapter) HasCommitsAhead(context.Context, string, string) (bool, error) {
 	return false, nil
+}
+
+func (f *fakeGitAdapter) ChangedFilesBetween(context.Context, string, string) ([]string, error) {
+	return nil, nil
 }
 
 func (f *fakeGitAdapter) record(method string, detail string) error {

--- a/tools/parsevkctl-go/internal/planner/plan.go
+++ b/tools/parsevkctl-go/internal/planner/plan.go
@@ -252,8 +252,7 @@ func NewCreatePullRequestPlan(input CreatePullRequestInput) (Plan, error) {
 	if err != nil {
 		return Plan{}, err
 	}
-	targetStatus, err := validateProjectStatus(input.TargetStatus)
-	if err != nil {
+	if _, err := validateProjectStatus(input.TargetStatus); err != nil {
 		return Plan{}, err
 	}
 
@@ -278,25 +277,15 @@ func NewCreatePullRequestPlan(input CreatePullRequestInput) (Plan, error) {
 			},
 		},
 		{
-			ID:          "project-set-status-" + statusID(targetStatus),
-			Type:        OperationProjectSetStatus,
-			Description: fmt.Sprintf("Set project status for issue #%d to %s", issueNumber, targetStatus),
+			ID:          "issue-update-review-labels",
+			Type:        OperationIssueUpdateLabels,
+			Description: fmt.Sprintf("Replace ai:in-progress with ai:needs-review on issue #%d", issueNumber),
 			SafeToRetry: true,
-			Payload:     ProjectStatusPayload{IssueNumber: issueNumber, Status: targetStatus},
-		},
-		{
-			ID:          "git-switch-default-branch",
-			Type:        OperationGitSwitch,
-			Description: fmt.Sprintf("Switch to %s", baseBranch),
-			SafeToRetry: true,
-			Payload:     GitBranchPayload{Branch: baseBranch},
-		},
-		{
-			ID:          "git-pull-fast-forward-default-branch",
-			Type:        OperationGitPullFastForward,
-			Description: fmt.Sprintf("Pull %s with --ff-only from origin", baseBranch),
-			SafeToRetry: true,
-			Payload:     GitRefPayload{Remote: originRemote, Branch: baseBranch},
+			Payload: IssueLabelsPayload{
+				IssueNumber: issueNumber,
+				Remove:      []string{"ai:in-progress"},
+				Add:         []string{"ai:needs-review"},
+			},
 		},
 	}
 

--- a/tools/parsevkctl-go/internal/planner/plan_test.go
+++ b/tools/parsevkctl-go/internal/planner/plan_test.go
@@ -92,9 +92,7 @@ func TestNewCreatePullRequestPlanOperationOrder(t *testing.T) {
 	want := []OperationType{
 		OperationGitPushBranch,
 		OperationPullRequestCreate,
-		OperationProjectSetStatus,
-		OperationGitSwitch,
-		OperationGitPullFastForward,
+		OperationIssueUpdateLabels,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("operation types = %#v, want %#v", got, want)
@@ -103,9 +101,7 @@ func TestNewCreatePullRequestPlanOperationOrder(t *testing.T) {
 	wantIDs := []string{
 		"git-push-task-branch",
 		"pull-request-create",
-		"project-set-status-review",
-		"git-switch-default-branch",
-		"git-pull-fast-forward-default-branch",
+		"issue-update-review-labels",
 	}
 	if got := operationIDs(plan); !reflect.DeepEqual(got, wantIDs) {
 		t.Fatalf("operation IDs = %#v, want %#v", got, wantIDs)


### PR DESCRIPTION
## Summary
- Implemented changes for issue #189.

## Issue

Closes #189

## Changed Files

- [ ] tools/parsevkctl-go/README.md
- [ ] tools/parsevkctl-go/internal/cli/cli.go
- [ ] tools/parsevkctl-go/internal/cli/cli_test.go
- [ ] tools/parsevkctl-go/internal/commands/commands_test.go
- [ ] tools/parsevkctl-go/internal/commands/review.go
- [ ] tools/parsevkctl-go/internal/commands/write.go
- [ ] tools/parsevkctl-go/internal/github/github.go
- [ ] tools/parsevkctl-go/internal/github/parse.go
- [ ] tools/parsevkctl-go/internal/github/shell.go
- [ ] tools/parsevkctl-go/internal/planner/executor_test.go

## Validation

- [ ] go fmt ./...
- [ ] go test ./...
- [ ] manual validation completed if required

## Risks

- Medium risk: this PR changes parsevkctl workflow behavior.

## AI Handoff

Next step:

- Review this PR in ChatGPT first.
- Do not leave an official GitHub review until explicitly requested.
