### PR TITLE
MBP-XXX: Add parsevkctl task status command

### DIFF
--- a/docs/PARSEVKCTL.md
+++ b/docs/PARSEVKCTL.md
@@ -107,6 +107,12 @@ go run ./cmd/parsevkctl task status 123
 go run ./cmd/parsevkctl task sync 123
 ```
 
+`task status <issue>` is diagnostic only. It reads issue metadata, labels,
+linked PR metadata, mergeability, GitHub checks, default branch, current branch,
+worktree cleanliness, expected task branch, and local/remote branch existence.
+It reports blockers and notes, infers the workflow stage, and prints one next
+`parsevkctl` command without changing GitHub or local git state.
+
 Preview write operations without mutating GitHub or local git state:
 
 ```powershell

--- a/tools/parsevkctl-go/README.md
+++ b/tools/parsevkctl-go/README.md
@@ -87,9 +87,13 @@ access and Project status availability where the adapter supports it. Human
 output uses `OK`, `WARN` and `FAIL` lines, and critical failures return a
 non-zero exit code.
 
-`parsevkctl task status <issue>` shows the issue, Project status, linked pull
-request, current branch, expected AI task branch, working tree state, derived
-lifecycle state and suggested next command.
+`parsevkctl task status <issue>` is a read-only diagnostic report. It shows
+issue metadata and labels, inferred workflow stage, repository default branch,
+current branch, expected AI task branch, clean or dirty worktree state, local
+and remote branch existence, linked pull request metadata, mergeability,
+`Closes #<issue>` linkage, GitHub checks when available, blockers, notes and
+one suggested next command. It does not update labels, Project fields, issues,
+pull requests or local branches.
 
 `parsevkctl task sync <issue>` is preview-only. It shows current state, drift
 items and suggested safe fixes, but does not update Project status, close

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -201,6 +201,55 @@ func TestTaskStatusReportsInconsistentLabelsAsUnknown(t *testing.T) {
 	deps.assertNoWrites(t)
 }
 
+func TestTaskStatusKeepsOpenPRWithPendingChecksInReview(t *testing.T) {
+	deps := okDeps()
+	deps.Git.currentBranch = "ai/mbp-112-add-read-only-task-commands"
+	deps.Git.localBranchExists = true
+	deps.Git.remoteBranchExists = true
+	deps.GitHub.issue.Labels = []string{"ai:needs-review"}
+	deps.GitHub.prs = []domain.PullRequest{{
+		Number: 7,
+		Title:  "MBP-112: Add read-only task commands",
+		State:  domain.PullRequestStateOpen,
+		Base:   deps.Config.DefaultBranch,
+		Head:   "ai/mbp-112-add-read-only-task-commands",
+	}}
+	deps.GitHub.prDetails = map[int]github.PullRequestDetails{
+		7: {
+			PullRequest: deps.GitHub.prs[0],
+			Body:        "Closes #112",
+			Mergeable:   github.MergeableStateMergeable,
+		},
+	}
+	deps.GitHub.checks = domain.PullRequestChecks{
+		PullRequestNumber: 7,
+		Total:             1,
+		Pending:           1,
+		Checks: []domain.PullRequestCheck{{
+			Name:   "parsevkctl / Validate Go CLI",
+			State:  domain.CheckStatePending,
+			Bucket: domain.CheckStatePending,
+		}},
+	}
+
+	result, err := BuildStatus(context.Background(), TaskStatusInput{
+		IssueNumber: 112,
+		Config:      deps.Config,
+		Git:         deps.Git,
+		GitHub:      deps.GitHub,
+	})
+	if err != nil {
+		t.Fatalf("BuildStatus returned error: %v", err)
+	}
+	if result.WorkflowStage != "Needs Review" {
+		t.Fatalf("stage = %q, want Needs Review", result.WorkflowStage)
+	}
+	if result.SuggestedCommand != "parsevkctl task review 112" {
+		t.Fatalf("next = %q, want review command", result.SuggestedCommand)
+	}
+	deps.assertNoWrites(t)
+}
+
 func TestDoctorAllOK(t *testing.T) {
 	deps := okDeps()
 	deps.ConfigValidation = config.ValidationResult{Path: "config.json", Valid: true}

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -36,15 +36,18 @@ func TestTaskStatusHumanNoPR(t *testing.T) {
 	}
 	text := out.String()
 	for _, want := range []string{
-		"Task status #112",
-		"Issue: Open",
-		"Project: unavailable",
-		"Pull request: none",
-		"Current branch: ai/mbp-112-read-only-commands",
-		"Expected branch: ai/mbp-112-add-read-only-task-commands",
-		"Working tree: clean",
-		"Lifecycle state: InProgress",
-		"Suggested next command: parsevkctl task pr <issue>",
+		"Task Status",
+		"- Number: #112",
+		"- State: OPEN",
+		"- Labels: ai:ready, type:infra",
+		"- Stage: Ready for AI",
+		"- Current branch: ai/mbp-112-read-only-commands",
+		"- Expected branch: ai/mbp-112-add-read-only-task-commands",
+		"- Worktree clean: true",
+		"- Local branch exists: false",
+		"- Remote branch exists: false",
+		"- None",
+		"parsevkctl task start 112",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("output missing %q:\n%s", want, text)
@@ -91,6 +94,109 @@ func TestTaskStatusJSONOpenPR(t *testing.T) {
 	}
 	if len(got.Warnings) != 0 {
 		t.Fatalf("warnings = %#v, want none", got.Warnings)
+	}
+	deps.assertNoWrites(t)
+}
+
+func TestTaskStatusHumanFullReportWithReadyToMergePR(t *testing.T) {
+	deps := okDeps()
+	deps.Git.currentBranch = "ai/mbp-112-add-read-only-task-commands"
+	deps.Git.defaultBranch = "fastapi-microservices-rewrite"
+	deps.Git.localBranchExists = true
+	deps.Git.remoteBranchExists = true
+	deps.GitHub.issue.Labels = []string{"ai:needs-review", "type:infra", "service:parsevkctl", "risk:low"}
+	deps.GitHub.project = domain.ProjectItem{ID: "item-1", Status: domain.ProjectStatusReview}
+	deps.GitHub.prs = []domain.PullRequest{{
+		Number: 7,
+		Title:  "MBP-112: Add read-only task commands",
+		State:  domain.PullRequestStateOpen,
+		URL:    "https://github.test/pr/7",
+		Base:   "fastapi-microservices-rewrite",
+		Head:   "ai/mbp-112-add-read-only-task-commands",
+	}}
+	deps.GitHub.prDetails = map[int]github.PullRequestDetails{
+		7: {
+			PullRequest: deps.GitHub.prs[0],
+			Body:        "Closes #112\n\n## Summary\n- done",
+			Mergeable:   github.MergeableStateMergeable,
+			Files:       []string{"tools/parsevkctl-go/internal/commands/status.go"},
+		},
+	}
+	deps.GitHub.checks = domain.PullRequestChecks{
+		PullRequestNumber: 7,
+		Total:             1,
+		Successful:        1,
+		Checks: []domain.PullRequestCheck{{
+			Name:   "go test ./...",
+			State:  domain.CheckStateSuccess,
+			Bucket: domain.CheckStateSuccess,
+		}},
+	}
+
+	var out bytes.Buffer
+	exit := RunTaskStatus(context.Background(), TaskStatusInput{
+		IssueNumber: 112,
+		Config:      deps.Config,
+		Git:         deps.Git,
+		GitHub:      deps.GitHub,
+		JSON:        false,
+		Stdout:      &out,
+		Stderr:      io.Discard,
+	})
+
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; output:\n%s", exit, out.String())
+	}
+	text := out.String()
+	for _, want := range []string{
+		"Task Status",
+		"- Number: #112",
+		"- Labels: ai:needs-review, type:infra, service:parsevkctl, risk:low",
+		"- Stage: Ready to Merge",
+		"- Default branch: fastapi-microservices-rewrite",
+		"- Current branch: ai/mbp-112-add-read-only-task-commands",
+		"- Local branch exists: true",
+		"- Remote branch exists: true",
+		"- Number: #7",
+		"- Mergeable: true",
+		"- Closes issue: true",
+		"- go test ./...: passed",
+		"- Blockers: none",
+		"parsevkctl task merge 112",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+	if deps.GitHub.checkCalls != 1 {
+		t.Fatalf("check calls = %d, want 1", deps.GitHub.checkCalls)
+	}
+	deps.assertNoWrites(t)
+}
+
+func TestTaskStatusReportsInconsistentLabelsAsUnknown(t *testing.T) {
+	deps := okDeps()
+	deps.GitHub.issue.Labels = []string{"ai:ready", "ai:needs-review"}
+	deps.Git.localBranchExists = false
+	deps.Git.remoteBranchExists = false
+
+	result, err := BuildStatus(context.Background(), TaskStatusInput{
+		IssueNumber: 112,
+		Config:      deps.Config,
+		Git:         deps.Git,
+		GitHub:      deps.GitHub,
+	})
+	if err != nil {
+		t.Fatalf("BuildStatus returned error: %v", err)
+	}
+	if result.WorkflowStage != "Unknown" {
+		t.Fatalf("stage = %q, want Unknown", result.WorkflowStage)
+	}
+	if result.SuggestedCommand != "Inspect labels and PR linkage manually." {
+		t.Fatalf("next = %q, want manual inspection", result.SuggestedCommand)
+	}
+	if len(result.Gate.Blockers) == 0 {
+		t.Fatalf("blockers = %#v, want inconsistent labels blocker", result.Gate.Blockers)
 	}
 	deps.assertNoWrites(t)
 }

--- a/tools/parsevkctl-go/internal/commands/status.go
+++ b/tools/parsevkctl-go/internal/commands/status.go
@@ -412,9 +412,6 @@ func inferWorkflowStage(issue domain.Issue, pr *domain.PullRequest, localBranchE
 	if issue.State == domain.IssueStateClosed && pr != nil && pr.Merged {
 		return "Done"
 	}
-	if len(gate.Blockers) > 0 && hasLabel(issue.Labels, "ai:needs-review") {
-		return "Blocked"
-	}
 	if issue.State == domain.IssueStateOpen && hasLabel(issue.Labels, "ai:ready") && !localBranchExists && !remoteBranchExists && pr == nil {
 		return "Ready for AI"
 	}

--- a/tools/parsevkctl-go/internal/commands/status.go
+++ b/tools/parsevkctl-go/internal/commands/status.go
@@ -32,8 +32,11 @@ type StatusResult struct {
 	Issue             IssueStatusResult        `json:"issue"`
 	Project           ProjectStatusResult      `json:"project"`
 	LinkedPullRequest *PullRequestStatusResult `json:"linkedPullRequest,omitempty"`
+	Checks            ChecksStatusResult       `json:"checks"`
 	Git               GitStatusResult          `json:"git"`
 	LifecycleState    domain.TaskState         `json:"lifecycleState"`
+	WorkflowStage     string                   `json:"workflowStage"`
+	Gate              StatusGateResult         `json:"gate"`
 	SuggestedCommand  string                   `json:"suggestedCommand"`
 	Warnings          []StatusWarning          `json:"warnings,omitempty"`
 }
@@ -42,6 +45,7 @@ type IssueStatusResult struct {
 	Number int               `json:"number"`
 	Title  string            `json:"title"`
 	State  domain.IssueState `json:"state"`
+	Labels []string          `json:"labels"`
 	URL    string            `json:"url,omitempty"`
 }
 
@@ -52,19 +56,44 @@ type ProjectStatusResult struct {
 }
 
 type PullRequestStatusResult struct {
-	Number int                     `json:"number"`
-	URL    string                  `json:"url,omitempty"`
-	State  domain.PullRequestState `json:"state"`
-	Draft  bool                    `json:"draft"`
-	Base   string                  `json:"base,omitempty"`
-	Head   string                  `json:"head,omitempty"`
+	Number       int                     `json:"number"`
+	Title        string                  `json:"title"`
+	URL          string                  `json:"url,omitempty"`
+	State        domain.PullRequestState `json:"state"`
+	Draft        bool                    `json:"draft"`
+	Base         string                  `json:"base,omitempty"`
+	Head         string                  `json:"head,omitempty"`
+	Mergeable    string                  `json:"mergeable"`
+	ClosesIssue  bool                    `json:"closesIssue"`
+	ChangedFiles []string                `json:"changedFiles,omitempty"`
 }
 
 type GitStatusResult struct {
-	CurrentBranch  string   `json:"currentBranch"`
-	ExpectedBranch string   `json:"expectedBranch"`
-	WorkTreeClean  bool     `json:"workTreeClean"`
-	ChangedFiles   []string `json:"changedFiles,omitempty"`
+	DefaultBranch                string   `json:"defaultBranch"`
+	CurrentBranch                string   `json:"currentBranch"`
+	ExpectedBranch               string   `json:"expectedBranch"`
+	WorkTreeClean                bool     `json:"workTreeClean"`
+	ChangedFiles                 []string `json:"changedFiles,omitempty"`
+	LocalBranchExists            bool     `json:"localBranchExists"`
+	RemoteBranchExists           bool     `json:"remoteBranchExists"`
+	HasCommitsAhead              *bool    `json:"hasCommitsAhead,omitempty"`
+	CurrentBranchMatchesExpected bool     `json:"currentBranchMatchesExpected"`
+}
+
+type ChecksStatusResult struct {
+	Available  bool     `json:"available"`
+	Lines      []string `json:"lines,omitempty"`
+	Total      int      `json:"total"`
+	Successful int      `json:"successful"`
+	Pending    int      `json:"pending"`
+	Failed     int      `json:"failed"`
+	Skipped    int      `json:"skipped"`
+	Message    string   `json:"message,omitempty"`
+}
+
+type StatusGateResult struct {
+	Blockers         []string `json:"blockers"`
+	NonBlockingNotes []string `json:"nonBlockingNotes"`
 }
 
 type StatusWarning struct {
@@ -123,6 +152,13 @@ func BuildStatus(ctx context.Context, input TaskStatusInput) (StatusResult, erro
 	if err != nil {
 		return StatusResult{}, fmt.Errorf("read current branch: %w", err)
 	}
+	defaultBranch, err := input.Git.DefaultBranch(ctx)
+	if err != nil {
+		return StatusResult{}, fmt.Errorf("detect default branch: %w", err)
+	}
+	if strings.TrimSpace(defaultBranch) == "" {
+		return StatusResult{}, fmt.Errorf("default branch cannot be detected")
+	}
 	clean, changedFiles, err := input.Git.IsWorkTreeClean(ctx)
 	if err != nil {
 		return StatusResult{}, fmt.Errorf("read working tree status: %w", err)
@@ -132,14 +168,52 @@ func BuildStatus(ctx context.Context, input TaskStatusInput) (StatusResult, erro
 	if err != nil {
 		return StatusResult{}, fmt.Errorf("derive expected task branch: %w", err)
 	}
+	localBranchExists, err := input.Git.LocalBranchExists(ctx, expectedBranch)
+	if err != nil {
+		return StatusResult{}, fmt.Errorf("check local branch %q: %w", expectedBranch, err)
+	}
+	remoteBranchExists, err := input.Git.RemoteBranchExists(ctx, "origin", expectedBranch)
+	if err != nil {
+		return StatusResult{}, fmt.Errorf("check remote branch %q: %w", expectedBranch, err)
+	}
+	var hasAhead *bool
+	if localBranchExists {
+		ahead, aheadErr := input.Git.HasCommitsAhead(ctx, defaultBranch, expectedBranch)
+		if aheadErr != nil {
+			warnings = append(warnings, StatusWarning{
+				Code:    "commits_ahead_unavailable",
+				Message: "could not check commits ahead: " + aheadErr.Error(),
+			})
+		} else {
+			hasAhead = &ahead
+		}
+	}
 
 	linkedPR := choosePullRequest(prs)
+	var linkedDetails github.PullRequestDetails
+	var linkedBody string
+	var mergeable github.MergeableState
+	var checksResult ChecksStatusResult
+	if linkedPR != nil {
+		linkedDetails, err = input.GitHub.GetPullRequestDetails(ctx, int(linkedPR.Number))
+		if err != nil {
+			return StatusResult{}, fmt.Errorf("get pull request #%d details: %w", linkedPR.Number, err)
+		}
+		pr := linkedDetails.PullRequest
+		linkedPR = &pr
+		linkedBody = linkedDetails.Body
+		mergeable = linkedDetails.Mergeable
+		checks, checkErr := input.GitHub.GetPullRequestChecks(ctx, int(linkedPR.Number))
+		checksResult = buildChecksStatus(checks, checkErr)
+	}
+	gate := buildStatusGate(input.IssueNumber, issue, expectedBranch, currentBranch, clean, linkedPR, linkedBody, mergeable, checksResult)
+	stage := inferWorkflowStage(issue, linkedPR, localBranchExists, remoteBranchExists, hasAhead, gate)
 	snapshot := task.LifecycleSnapshot{
 		IssueExists:        true,
 		IssueState:         issue.State,
 		ProjectStatus:      project.Status,
-		LocalBranchExists:  isTaskBranchForIssue(currentBranch, input.IssueNumber, expectedBranch),
-		RemoteBranchExists: linkedPR != nil && linkedPR.Head == expectedBranch,
+		LocalBranchExists:  localBranchExists,
+		RemoteBranchExists: remoteBranchExists,
 	}
 	if linkedPR != nil {
 		snapshot.PullRequestState = linkedPR.State
@@ -153,27 +227,40 @@ func BuildStatus(ctx context.Context, input TaskStatusInput) (StatusResult, erro
 			Number: int(issue.ID),
 			Title:  issue.Title,
 			State:  issue.State,
+			Labels: append([]string(nil), issue.Labels...),
 			URL:    issue.URL,
 		},
 		Project: project,
+		Checks:  checksResult,
 		Git: GitStatusResult{
-			CurrentBranch:  currentBranch,
-			ExpectedBranch: expectedBranch,
-			WorkTreeClean:  clean,
-			ChangedFiles:   changedFiles,
+			DefaultBranch:                defaultBranch,
+			CurrentBranch:                currentBranch,
+			ExpectedBranch:               expectedBranch,
+			WorkTreeClean:                clean,
+			ChangedFiles:                 changedFiles,
+			LocalBranchExists:            localBranchExists,
+			RemoteBranchExists:           remoteBranchExists,
+			HasCommitsAhead:              hasAhead,
+			CurrentBranchMatchesExpected: currentBranch == expectedBranch,
 		},
 		LifecycleState:   lifecycleState,
-		SuggestedCommand: task.SuggestedNextCommand(lifecycleState),
+		WorkflowStage:    stage,
+		Gate:             gate,
+		SuggestedCommand: suggestedStatusCommand(stage, input.IssueNumber),
 		Warnings:         warnings,
 	}
 	if linkedPR != nil {
 		result.LinkedPullRequest = &PullRequestStatusResult{
-			Number: int(linkedPR.Number),
-			URL:    linkedPR.URL,
-			State:  linkedPR.State,
-			Draft:  linkedPR.Draft,
-			Base:   linkedPR.Base,
-			Head:   linkedPR.Head,
+			Number:       int(linkedPR.Number),
+			Title:        linkedPR.Title,
+			URL:          linkedPR.URL,
+			State:        linkedPR.State,
+			Draft:        linkedPR.Draft,
+			Base:         linkedPR.Base,
+			Head:         linkedPR.Head,
+			Mergeable:    renderMergeable(mergeable),
+			ClosesIssue:  closesIssue(linkedBody, input.IssueNumber),
+			ChangedFiles: append([]string(nil), linkedDetails.Files...),
 		}
 	}
 
@@ -193,40 +280,227 @@ func renderStatus(w io.Writer, result StatusResult, jsonOutput bool) error {
 		return nil
 	}
 
-	fmt.Fprintf(w, "Task status #%d\n", result.Issue.Number)
-	fmt.Fprintf(w, "Title: %s\n", result.Issue.Title)
-	fmt.Fprintf(w, "Issue: %s\n", result.Issue.State)
-	if result.Issue.URL != "" {
-		fmt.Fprintf(w, "Issue URL: %s\n", result.Issue.URL)
+	fmt.Fprintln(w, "Task Status")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Issue:")
+	fmt.Fprintf(w, "- Number: #%d\n", result.Issue.Number)
+	fmt.Fprintf(w, "- Title: %s\n", result.Issue.Title)
+	fmt.Fprintf(w, "- State: %s\n", strings.ToUpper(string(result.Issue.State)))
+	fmt.Fprintf(w, "- Labels: %s\n", renderCSV(result.Issue.Labels, "none"))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Workflow:")
+	fmt.Fprintf(w, "- Stage: %s\n", result.WorkflowStage)
+	fmt.Fprintf(w, "- Expected branch: %s\n", result.Git.ExpectedBranch)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Git:")
+	fmt.Fprintf(w, "- Default branch: %s\n", result.Git.DefaultBranch)
+	fmt.Fprintf(w, "- Current branch: %s\n", result.Git.CurrentBranch)
+	fmt.Fprintf(w, "- Worktree clean: %t\n", result.Git.WorkTreeClean)
+	fmt.Fprintf(w, "- Local branch exists: %t\n", result.Git.LocalBranchExists)
+	fmt.Fprintf(w, "- Remote branch exists: %t\n", result.Git.RemoteBranchExists)
+	if result.Git.HasCommitsAhead != nil {
+		fmt.Fprintf(w, "- Has commits ahead: %t\n", *result.Git.HasCommitsAhead)
 	}
-	if result.Project.Available {
-		fmt.Fprintf(w, "Project: %s\n", result.Project.Status)
-	} else {
-		fmt.Fprintln(w, "Project: unavailable")
-	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Pull Request:")
 	if result.LinkedPullRequest == nil {
-		fmt.Fprintln(w, "Pull request: none")
+		fmt.Fprintln(w, "- None")
 	} else {
 		pr := result.LinkedPullRequest
-		fmt.Fprintf(w, "Pull request: #%d %s draft=%t base=%s head=%s\n", pr.Number, pr.State, pr.Draft, pr.Base, pr.Head)
-		if pr.URL != "" {
-			fmt.Fprintf(w, "Pull request URL: %s\n", pr.URL)
-		}
+		fmt.Fprintf(w, "- Number: #%d\n", pr.Number)
+		fmt.Fprintf(w, "- Title: %s\n", pr.Title)
+		fmt.Fprintf(w, "- State: %s\n", strings.ToUpper(string(pr.State)))
+		fmt.Fprintf(w, "- Draft: %t\n", pr.Draft)
+		fmt.Fprintf(w, "- Base: %s\n", pr.Base)
+		fmt.Fprintf(w, "- Head: %s\n", pr.Head)
+		fmt.Fprintf(w, "- Mergeable: %s\n", pr.Mergeable)
+		fmt.Fprintf(w, "- Closes issue: %t\n", pr.ClosesIssue)
 	}
-	fmt.Fprintf(w, "Current branch: %s\n", result.Git.CurrentBranch)
-	fmt.Fprintf(w, "Expected branch: %s\n", result.Git.ExpectedBranch)
-	if result.Git.WorkTreeClean {
-		fmt.Fprintln(w, "Working tree: clean")
-	} else {
-		fmt.Fprintln(w, "Working tree: dirty")
-	}
-	fmt.Fprintf(w, "Lifecycle state: %s\n", result.LifecycleState)
-	fmt.Fprintf(w, "Suggested next command: %s\n", result.SuggestedCommand)
+	fmt.Fprintln(w)
+	renderStatusChecks(w, result.Checks)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Gate:")
+	renderStatusList(w, "- Blockers:", result.Gate.Blockers, "none")
+	renderStatusList(w, "- Non-blocking notes:", result.Gate.NonBlockingNotes, "none")
 	for _, warning := range result.Warnings {
-		fmt.Fprintf(w, "Warning: %s\n", warning.Message)
+		fmt.Fprintf(w, "- Warning: %s\n", warning.Message)
 	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Next:")
+	fmt.Fprintln(w, result.SuggestedCommand)
 
 	return nil
+}
+
+func buildChecksStatus(checks domain.PullRequestChecks, err error) ChecksStatusResult {
+	if err != nil {
+		return ChecksStatusResult{Message: "Could not read GitHub checks: " + err.Error()}
+	}
+	result := ChecksStatusResult{
+		Available:  true,
+		Total:      checks.Total,
+		Successful: checks.Successful,
+		Pending:    checks.Pending,
+		Failed:     checks.Failed,
+		Skipped:    checks.Skipped,
+	}
+	for _, check := range checks.Checks {
+		result.Lines = append(result.Lines, fmt.Sprintf("%s: %s", check.Name, checkBucketText(check.Bucket)))
+	}
+	if checks.Total == 0 || len(checks.Checks) == 0 {
+		result.Message = "No GitHub checks found"
+	}
+	return result
+}
+
+func buildStatusGate(issueNumber int, issue domain.Issue, expectedBranch string, currentBranch string, clean bool, pr *domain.PullRequest, body string, mergeable github.MergeableState, checks ChecksStatusResult) StatusGateResult {
+	var blockers []string
+	var notes []string
+	if countAILifecycleLabels(issue.Labels) > 1 {
+		blockers = append(blockers, "issue has multiple ai lifecycle labels")
+	}
+	if hasLabel(issue.Labels, "review:failed") || hasLabel(issue.Labels, "review:changes-requested") {
+		blockers = append(blockers, "issue has blocking review label")
+	}
+	if !clean {
+		blockers = append(blockers, "local worktree is dirty")
+	}
+	if currentBranch != expectedBranch {
+		notes = append(notes, fmt.Sprintf("current branch %q does not match expected branch %q", currentBranch, expectedBranch))
+	}
+	if hasLabel(issue.Labels, "ai:needs-review") && pr == nil {
+		blockers = append(blockers, "issue has ai:needs-review but no linked PR was found")
+	}
+	if pr != nil {
+		if pr.Head != expectedBranch {
+			blockers = append(blockers, fmt.Sprintf("pull request head %q does not match expected branch %q", pr.Head, expectedBranch))
+		}
+		if !closesIssue(body, issueNumber) {
+			blockers = append(blockers, fmt.Sprintf("pull request #%d body does not contain Closes #%d", pr.Number, issueNumber))
+		}
+		if pr.Draft {
+			blockers = append(blockers, fmt.Sprintf("pull request #%d is draft", pr.Number))
+		}
+		if pr.State != domain.PullRequestStateOpen && !pr.Merged {
+			blockers = append(blockers, fmt.Sprintf("pull request #%d is not open", pr.Number))
+		}
+		if mergeable == github.MergeableStateConflicting {
+			blockers = append(blockers, fmt.Sprintf("pull request #%d has merge conflicts", pr.Number))
+		} else if mergeable != github.MergeableStateMergeable {
+			notes = append(notes, fmt.Sprintf("pull request #%d mergeability is %q", pr.Number, mergeable))
+		}
+	}
+	if checks.Message != "" {
+		notes = append(notes, checks.Message)
+	}
+	if checks.Failed > 0 {
+		blockers = append(blockers, "pull request has failed checks")
+	}
+	if checks.Pending > 0 {
+		blockers = append(blockers, "pull request has pending checks")
+	}
+	return StatusGateResult{Blockers: blockers, NonBlockingNotes: notes}
+}
+
+func inferWorkflowStage(issue domain.Issue, pr *domain.PullRequest, localBranchExists bool, remoteBranchExists bool, hasAhead *bool, gate StatusGateResult) string {
+	if hasLabel(issue.Labels, "review:failed") || hasLabel(issue.Labels, "review:changes-requested") {
+		return "Blocked"
+	}
+	if countAILifecycleLabels(issue.Labels) > 1 {
+		return "Unknown"
+	}
+	if issue.State == domain.IssueStateClosed && pr != nil && pr.Merged {
+		return "Done"
+	}
+	if len(gate.Blockers) > 0 && hasLabel(issue.Labels, "ai:needs-review") {
+		return "Blocked"
+	}
+	if issue.State == domain.IssueStateOpen && hasLabel(issue.Labels, "ai:ready") && !localBranchExists && !remoteBranchExists && pr == nil {
+		return "Ready for AI"
+	}
+	if issue.State == domain.IssueStateOpen && hasLabel(issue.Labels, "ai:in-progress") && (localBranchExists || remoteBranchExists) && pr == nil {
+		if hasAhead != nil && *hasAhead {
+			return "Needs PR"
+		}
+		return "In Progress"
+	}
+	if issue.State == domain.IssueStateOpen && hasLabel(issue.Labels, "ai:needs-review") && pr != nil && pr.State == domain.PullRequestStateOpen {
+		if len(gate.Blockers) == 0 {
+			return "Ready to Merge"
+		}
+		return "Needs Review"
+	}
+	if issue.State == domain.IssueStateClosed {
+		return "Done"
+	}
+	if len(gate.Blockers) > 0 {
+		return "Blocked"
+	}
+	return "Unknown"
+}
+
+func suggestedStatusCommand(stage string, issueNumber int) string {
+	switch stage {
+	case "Ready for AI":
+		return fmt.Sprintf("parsevkctl task start %d", issueNumber)
+	case "In Progress", "Needs PR":
+		return fmt.Sprintf("parsevkctl task pr %d", issueNumber)
+	case "Needs Review":
+		return fmt.Sprintf("parsevkctl task review %d", issueNumber)
+	case "Ready to Merge":
+		return fmt.Sprintf("parsevkctl task merge %d", issueNumber)
+	case "Done":
+		return "No action needed."
+	default:
+		return "Inspect labels and PR linkage manually."
+	}
+}
+
+func countAILifecycleLabels(labels []string) int {
+	count := 0
+	for _, label := range []string{"ai:ready", "ai:in-progress", "ai:needs-review"} {
+		if hasLabel(labels, label) {
+			count++
+		}
+	}
+	return count
+}
+
+func closesIssue(body string, issueNumber int) bool {
+	return strings.Contains(body, fmt.Sprintf("Closes #%d", issueNumber))
+}
+
+func renderCSV(values []string, empty string) string {
+	if len(values) == 0 {
+		return empty
+	}
+	return strings.Join(values, ", ")
+}
+
+func renderStatusChecks(w io.Writer, checks ChecksStatusResult) {
+	fmt.Fprintln(w, "Checks:")
+	if checks.Message != "" && len(checks.Lines) == 0 {
+		fmt.Fprintf(w, "- %s\n", checks.Message)
+		return
+	}
+	if len(checks.Lines) == 0 {
+		fmt.Fprintln(w, "- No GitHub checks found")
+		return
+	}
+	for _, line := range checks.Lines {
+		fmt.Fprintf(w, "- %s\n", line)
+	}
+}
+
+func renderStatusList(w io.Writer, title string, values []string, empty string) {
+	if len(values) == 0 {
+		fmt.Fprintf(w, "%s %s\n", title, empty)
+		return
+	}
+	fmt.Fprintln(w, title)
+	for _, value := range values {
+		fmt.Fprintf(w, "  - %s\n", value)
+	}
 }
 
 func choosePullRequest(prs []domain.PullRequest) *domain.PullRequest {


### PR DESCRIPTION
## Summary
- Implemented changes for issue #203.

## Issue

Closes #203

## Changed Files

- [ ] docs/PARSEVKCTL.md
- [ ] tools/parsevkctl-go/README.md
- [ ] tools/parsevkctl-go/internal/commands/commands_test.go
- [ ] tools/parsevkctl-go/internal/commands/status.go

## Validation

- [ ] go fmt ./...
- [ ] go test ./...
- [ ] manual validation completed if required

## Risks

- Medium risk: this PR changes parsevkctl workflow behavior.

## AI Handoff

Next step:

- Review this PR in ChatGPT first.
- Do not leave an official GitHub review until explicitly requested.
