### PR TITLE
docs(skills): add parsevk repo-scoped codex workflows

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,26 @@
+# parseVK Repo-Scoped Codex Skills
+
+These are Codex repository-scoped skills for the parseVK AI-assisted development workflow.
+
+Codex repository skills belong under:
+
+```text
+.agents/skills/
+```
+
+Each skill is a directory with a required `SKILL.md` file. Optional supporting files may live under `references/`, `scripts/`, `assets/`, or `agents/` inside that skill directory.
+
+Do not place Codex skills under `docs/ai-skills/`. The `docs/` directory remains for human-facing project documentation and long-term architecture notes.
+
+The workflow architecture is:
+
+```text
+GitHub Issue = task source of truth
+GitHub PR = implementation artifact
+Codex Skill = reusable reasoning/process guide
+parsevkctl = deterministic helper CLI
+docs/ = long-term human/project documentation
+.agents/skills = repo-scoped AI workflow skills
+```
+
+`parsevkctl` should remain a thin deterministic CLI for task lifecycle operations. Complex AI reasoning workflows belong in skills. GitHub Issues and Pull Requests remain the source of truth for task scope, implementation state, review, and merge decisions.

--- a/.agents/skills/parsevk-codex-implementation/SKILL.md
+++ b/.agents/skills/parsevk-codex-implementation/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: parsevk-codex-implementation
+description: Use when implementing a scoped parseVK GitHub Issue with Codex; follow the linked issue, preserve scope, run relevant validation, and produce a final handoff. Do not use for issue drafting, PR review, merge approval, or unrelated refactors.
+---
+
+# parseVK Codex Implementation
+
+## When to use
+
+Use this skill when Codex is implementing an existing parseVK GitHub Issue.
+
+The GitHub Issue is the source of truth for the task. The PR is the implementation artifact.
+
+## When not to use
+
+Do not use this skill for creating the issue, reviewing another PR, deciding whether to merge, or making broad refactors outside the issue scope.
+
+Do not use it when the current branch does not match the issue branch, the working tree contains unrelated changes that would be touched, or the task requires secrets or production access.
+
+## Inputs
+
+- Issue number and body
+- Current branch and git status
+- Acceptance criteria
+- Out-of-scope section
+- Relevant validation commands
+
+## Procedure
+
+1. Read the issue before editing.
+2. Confirm the branch matches the task and is not a default branch.
+3. Inspect the working tree and avoid user changes unrelated to the issue.
+4. Implement only the requested scope.
+5. Respect the out-of-scope section.
+6. Avoid unrelated refactors, formatting churn, dependency changes, and service changes.
+7. Keep `parsevkctl` deterministic and thin; do not add AI reasoning as CLI behavior.
+8. Run relevant validation commands from project metadata such as `package.json`, `pyproject.toml`, `Makefile`, or task instructions.
+9. Never claim tests or checks passed unless they actually ran and completed successfully.
+10. Commit with a Conventional Commit subject in English and include issue links in the body when appropriate.
+11. Create the PR through `parsevkctl task pr ISSUE_NUMBER` when implementation and validation are ready.
+
+## Output format
+
+Final handoff must include:
+
+```md
+## Summary
+- ...
+
+## Changed files
+- ...
+
+## Validation
+- `command` - result
+
+## Risks
+- ...
+
+## Not done
+- ...
+
+## Next
+- ...
+```
+
+## Safety rules
+
+- Do not modify application services unless the issue explicitly requires it.
+- Do not modify frontend, Docker, database, CI/CD, or GitHub Actions unless explicitly in scope.
+- Do not include `.env`, secrets, tokens, keys, cookies, or private config.
+- Do not run destructive git commands.
+- Do not mix unrelated tasks in one PR.
+
+## Validation expectations
+
+Prefer focused checks that match the changed files. If checks cannot run, state the exact command attempted, the failure reason, and the impact on confidence.

--- a/.agents/skills/parsevk-github-task-planning/SKILL.md
+++ b/.agents/skills/parsevk-github-task-planning/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: parsevk-github-task-planning
+description: Use when planning or drafting parseVK GitHub Issues for AI-assisted development; create one small AI-safe task with clear scope, labels, risk, validation, and handoff. Do not use for implementation, PR review, merge decisions, or broad roadmap planning.
+---
+
+# parseVK GitHub Task Planning
+
+## When to use
+
+Use this skill when creating or refining a GitHub Issue that will be implemented by Codex or another AI agent in the parseVK repository.
+
+The issue must be the unit of AI work: one issue, one bounded task, one expected PR.
+
+## When not to use
+
+Do not use this skill to implement code, review a PR, decide whether to merge, or plan a multi-issue roadmap without splitting it into small tasks.
+
+Do not use it for tasks that require production access, secrets, protected branch changes, or undefined ownership.
+
+## Inputs
+
+- User request or project need
+- Relevant service area
+- Known constraints and out-of-scope boundaries
+- Expected validation commands
+- Risk level
+
+## Procedure
+
+1. Define a narrow goal that can be completed in one focused AI session.
+2. Write the issue title in a concise task format.
+3. Fill the issue body with:
+   - Goal
+   - Background
+   - Scope
+   - Out of Scope
+   - Acceptance Criteria
+   - Validation
+   - Risk
+   - AI Session Budget
+   - Required Handoff
+4. Add labels for type, service area, risk, and AI readiness.
+5. Keep `parsevkctl` as the deterministic lifecycle helper. Do not move complex reasoning into new CLI behavior.
+6. Ensure the task can be reviewed from the issue and PR without private context.
+
+## Output format
+
+Return:
+
+```md
+## Title
+
+...
+
+## Labels
+
+- type:...
+- service:...
+- risk:...
+- ai:ready
+
+## Body
+
+...
+```
+
+## Safety rules
+
+- One issue equals one AI-safe task.
+- Scope must be explicit and small.
+- Out-of-scope work must be named clearly.
+- Do not include secrets, credentials, tokens, cookies, or private config.
+- Do not ask AI agents to modify unrelated services.
+- Do not create tasks that require force push, destructive git commands, or protected-branch changes.
+
+## Validation expectations
+
+Every issue must name concrete validation steps. If no automated validation is available, state the manual validation and why automated checks do not apply.

--- a/.agents/skills/parsevk-handoff/SKILL.md
+++ b/.agents/skills/parsevk-handoff/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: parsevk-handoff
+description: Use at the end of a parseVK implementation or PR review to produce the required AI handoff with summary, files, validation, risks, omissions, and next suggested issue. Do not use for planning, implementation, review analysis, or merge decisions by itself.
+---
+
+# parseVK Handoff
+
+## When to use
+
+Use this skill after implementation, after PR review, or when pausing work so the next person or AI session can continue from a clear state.
+
+## When not to use
+
+Do not use this skill instead of doing validation, review, or merge checks. It is a reporting format, not a substitute for evidence.
+
+## Inputs
+
+- Issue number
+- Branch name
+- PR URL if created
+- Changed files
+- Validation commands and results
+- Known risks
+- Work intentionally not done
+- Suggested follow-up
+
+## Procedure
+
+1. Summarize what changed in user-facing terms.
+2. List changed files or changed areas.
+3. Report validation commands that actually ran and their results.
+4. State skipped validation and why it was skipped.
+5. Name risks or residual uncertainty.
+6. State what was not done.
+7. Suggest the next issue only when it follows from the completed work.
+
+## Output format
+
+```md
+## Summary
+- ...
+
+## Changed files
+- ...
+
+## Validation
+- `command` - passed/failed/skipped, with reason
+
+## Risks
+- ...
+
+## Not done
+- ...
+
+## Next suggested issue
+- ...
+```
+
+## Safety rules
+
+- Do not claim tests passed unless they ran.
+- Do not hide failed, skipped, or unavailable checks.
+- Do not include secrets or sensitive local paths beyond repository file paths.
+- Do not imply merge completion unless the merge command actually succeeded.
+
+## Validation expectations
+
+The handoff must let another maintainer understand what evidence exists, what remains uncertain, and what command or review step should happen next.

--- a/.agents/skills/parsevk-merge-gate/SKILL.md
+++ b/.agents/skills/parsevk-merge-gate/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: parsevk-merge-gate
+description: Use when deciding whether a parseVK PR is ready to merge; verify open non-draft PR state, correct base, linked issue, scope, checks, secrets, and review blockers. Do not use for implementation, issue drafting, or official GitHub approval.
+---
+
+# parseVK Merge Gate
+
+## When to use
+
+Use this skill when deciding whether a parseVK PR can be merged or when checking merge readiness after review.
+
+## When not to use
+
+Do not use this skill to implement fixes, draft issues, create PRs, or submit GitHub approvals.
+
+Do not use it to bypass branch protection, failing checks, unresolved blockers, or missing issue linkage.
+
+## Inputs
+
+- Issue number
+- PR number
+- PR state and draft status
+- base branch
+- linked issue reference
+- changed files
+- checks
+- review findings
+
+## Procedure
+
+1. Confirm the PR is open.
+2. Confirm the PR is not draft.
+3. Confirm the base branch is correct for the task.
+4. Confirm the PR links or closes the intended issue.
+5. Confirm changed files match the issue scope.
+6. Confirm checks are passing or any missing/failing checks are explicitly explained.
+7. Scan changed paths and diff for obvious secrets or private config.
+8. Confirm there are no blocking review findings.
+9. Do not require GitHub approve from the same user.
+10. If ready, use `parsevkctl task merge ISSUE_NUMBER` for the lifecycle merge.
+
+## Output format
+
+```md
+## Merge gate
+- PR open: yes/no
+- Draft: yes/no
+- Base branch: ok/not ok
+- Linked issue: ok/not ok
+- Scope: ok/not ok
+- Checks: ok/not ok
+- Secrets: ok/not ok
+- Blockers: none/list
+
+## Decision
+Можно мержить / Пока не мержить / Нужно больше проверки
+```
+
+## Safety rules
+
+- Never merge from the default branch as a task branch.
+- Never merge with unresolved conflicts.
+- Never merge obvious secrets, `.env`, private keys, tokens, cookies, or passwords.
+- Stop before merge for security/auth changes, deployment changes, migrations, CI/CD changes, or large refactors unless review explicitly clears them.
+
+## Validation expectations
+
+Use actual PR and check data where available. If GitHub checks are unavailable, state that and identify the local validation that supports or limits the decision.

--- a/.agents/skills/parsevk-pr-review/SKILL.md
+++ b/.agents/skills/parsevk-pr-review/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: parsevk-pr-review
+description: Use when reviewing a parseVK Pull Request in chat before any GitHub review; inspect PR metadata, linked issue, changed files, validation evidence, and scope fit. Do not use to implement fixes, merge PRs, or submit an official GitHub review unless explicitly requested.
+---
+
+# parseVK PR Review
+
+## When to use
+
+Use this skill when the user asks Codex or ChatGPT to review a parseVK PR, inspect PR readiness, or provide merge guidance.
+
+Review findings in chat first. Do not write a GitHub PR review unless the user explicitly asks for it.
+
+For detailed workflow guidance, read `references/PR_REVIEW_WORKFLOW.md`.
+
+## When not to use
+
+Do not use this skill to implement requested fixes, merge the PR, create an official GitHub approval, or review unrelated branches without a PR.
+
+Do not treat an approval from the same GitHub user as required for merge readiness.
+
+## Inputs
+
+- PR number or URL
+- Linked GitHub Issue
+- PR title and body
+- Changed files and diff
+- Validation evidence from the PR body, comments, checks, or local commands
+
+## Procedure
+
+1. Inspect PR metadata: state, draft status, base branch, head branch, title, body, and linked issue.
+2. Inspect the linked issue and compare scope, out-of-scope rules, acceptance criteria, and labels.
+3. Inspect changed files and diff.
+4. Verify that changes match the issue scope.
+5. Check validation evidence. Distinguish checks that ran from checks merely listed.
+6. Look for secrets, risky config changes, CI/CD changes, auth/security changes, migrations, and broad refactors.
+7. Separate blocking findings from non-blocking notes.
+8. Give one final verdict:
+   - Можно мержить
+   - Пока не мержить
+   - Нужны правки
+   - Нужно больше проверки
+
+## Output format
+
+```md
+## Verdict
+...
+
+## Blockers
+- ...
+
+## Notes
+- ...
+
+## Validation
+- ...
+
+## Scope check
+- ...
+```
+
+If there are no blockers, say that clearly.
+
+## Safety rules
+
+- Chat-first review is mandatory.
+- Do not submit a GitHub review without explicit user request.
+- Do not require GitHub approve from the same user.
+- Do not ignore out-of-scope file changes.
+- Do not approve PRs with obvious secrets or unexplained failing checks.
+
+## Validation expectations
+
+Prefer direct evidence from PR checks, local validation output, and changed files. If evidence is missing, mark it as missing instead of assuming checks passed.

--- a/.agents/skills/parsevk-pr-review/references/PR_REVIEW_WORKFLOW.md
+++ b/.agents/skills/parsevk-pr-review/references/PR_REVIEW_WORKFLOW.md
@@ -1,0 +1,107 @@
+# parseVK PR Review Workflow
+
+This workflow defines how Codex or ChatGPT should review parseVK Pull Requests.
+
+## Core rule
+
+Review happens in chat first. Do not submit an official GitHub PR review, approval, or request changes unless the user explicitly asks for that GitHub action.
+
+## Review inputs
+
+Collect:
+
+- PR number or URL
+- PR state and draft status
+- base branch and head branch
+- PR title and body
+- linked issue and `Closes #...` reference
+- changed files
+- diff
+- validation evidence
+- check status
+
+## Scope review
+
+Compare the PR against the linked issue:
+
+- Goal
+- Scope
+- Out of Scope
+- Acceptance Criteria
+- Validation
+- Risk
+- Required Handoff
+
+Flag any changed file that is not explained by the issue. Application services, frontend, Docker, database, CI/CD, and GitHub Actions require explicit issue scope.
+
+## Validation review
+
+Separate evidence from claims:
+
+- Passing GitHub checks are evidence.
+- Local command output is evidence.
+- PR body checkboxes are claims unless paired with output or check results.
+- Missing validation must be called out.
+- Failed or pending checks block merge unless explicitly explained and accepted.
+
+## Risk review
+
+Look for:
+
+- secrets, tokens, keys, cookies, private config, or `.env` files
+- authentication or authorization changes
+- database migrations or schema changes
+- deployment or CI/CD changes
+- broad refactors
+- generated files or lockfile changes outside scope
+- unrelated service changes
+
+## Findings
+
+Use blockers for issues that should prevent merge:
+
+- scope mismatch
+- missing required validation
+- failing checks
+- likely bug or regression
+- security or secret exposure
+- unsafe merge state
+
+Use notes for non-blocking observations:
+
+- naming, clarity, small cleanup
+- optional follow-up
+- documentation polish
+- test coverage suggestions when risk is low
+
+## Final verdicts
+
+Use exactly one:
+
+- `Можно мержить` - no blockers, scope fits, validation is adequate.
+- `Пока не мержить` - clear blocker prevents merge.
+- `Нужны правки` - implementation changes are required before merge.
+- `Нужно больше проверки` - no definite code blocker, but validation evidence is insufficient.
+
+## Output template
+
+```md
+## Verdict
+<one verdict>
+
+## Blockers
+- <none or list>
+
+## Notes
+- <none or list>
+
+## Validation
+- <checks reviewed and missing evidence>
+
+## Scope check
+- <whether changed files match issue scope>
+```
+
+## GitHub review actions
+
+Only after explicit user request, convert the chat review into a GitHub PR review. Keep the GitHub review concise and do not change the verdict unless new evidence appears.


### PR DESCRIPTION
Closes #205

## Summary
- Add repo-scoped Codex skills under `.agents/skills/` for parseVK task planning, implementation, PR review, merge gate, and handoff workflows.
- Add PR review reference material under the `parsevk-pr-review` skill.
- Document the repo-scoped skills architecture and keep `parsevkctl` as a deterministic helper CLI.

## Validation
- [x] `git diff --cached --name-only` before commit showed only `.agents/skills/` paths.
- [x] `Get-ChildItem -Path .agents/skills -Filter SKILL.md -Recurse` found all five required `SKILL.md` files.
- [x] PowerShell frontmatter check confirmed each `SKILL.md` has opening/closing frontmatter with `name` and `description`.
- [x] `Test-Path docs/ai-skills` returned absent.