### PR TITLE
docs: add notes and task workflow scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,56 @@
+name: Bug
+description: Report a reproducible defect
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: What is broken?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      value: |
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: OS, command, branch, commit, service, relevant config.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ] Bug is fixed.
+        - [ ] Regression risk is covered by test or documented manual check.
+        - [ ] No unrelated changes.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/codex-task.yml
+++ b/.github/ISSUE_TEMPLATE/codex-task.yml
@@ -1,0 +1,80 @@
+name: Codex task
+description: Implementation task intended for Codex or another coding agent
+title: "[codex] "
+labels: ["codex", "task"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is the current situation?
+      placeholder: Describe why this task exists.
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be changed?
+      placeholder: Describe the intended final state.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Which files/modules may be changed? What is out of scope?
+      value: |
+        Allowed:
+        - 
+
+        Out of scope:
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete checklist that must be true before the issue can close.
+      value: |
+        - [ ] 
+        - [ ] 
+        - [ ] 
+    validations:
+      required: true
+
+  - type: textarea
+    id: safety
+    attributes:
+      label: Safety requirements
+      value: |
+        - [ ] No secrets, tokens, cookies, passwords, or production credentials.
+        - [ ] No unrelated file changes.
+        - [ ] Existing CLI/API workflow remains compatible.
+        - [ ] Failure modes are explicit and safe.
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Tests or manual checks expected for this task.
+      value: |
+        - [ ] Tests were added or updated, where appropriate.
+        - [ ] Manual verification steps are documented in the PR.
+    validations:
+      required: true
+
+  - type: textarea
+    id: source
+    attributes:
+      label: Source note
+      description: Optional Obsidian/private note reference.
+      placeholder: parsevk-notes-vault/...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: parseVK internal notes
+    url: https://github.com/
+    about: Keep raw ideas in the private notes vault first. Convert only ready items to issues.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,31 @@
+name: Docs
+description: Documentation task
+title: "[docs] "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      placeholder: What documentation is missing, stale, or misleading?
+    validations:
+      required: true
+
+  - type: textarea
+    id: docs_target
+    attributes:
+      label: Documentation target
+      placeholder: Which docs/files should be added or updated?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ] Documentation is accurate.
+        - [ ] Examples are runnable or clearly marked as illustrative.
+        - [ ] Links and commands are valid.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,51 @@
+name: Feature
+description: Request a new capability
+title: "[feature] "
+labels: ["feature"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      placeholder: Why is this feature needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Desired behavior
+      placeholder: What should the system do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      value: |
+        In scope:
+        - 
+
+        Out of scope:
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ] 
+        - [ ] 
+        - [ ] 
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,41 @@
+name: Refactor
+description: Improve structure without changing expected behavior
+title: "[refactor] "
+labels: ["refactor"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      placeholder: What design or maintainability problem exists?
+    validations:
+      required: true
+
+  - type: textarea
+    id: target
+    attributes:
+      label: Refactor target
+      placeholder: Which modules/files/workflows are affected?
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      value: |
+        - No unrelated behavior changes.
+        - No broad rewrites outside the stated scope.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      value: |
+        - [ ] Existing behavior remains compatible.
+        - [ ] Code is simpler or better separated.
+        - [ ] Tests/checks/manual verification are documented.
+    validations:
+      required: true

--- a/docs/adr/ADR-000-template.md
+++ b/docs/adr/ADR-000-template.md
@@ -1,0 +1,27 @@
+# ADR-000: <Decision title>
+
+## Status
+proposed
+
+## Date
+YYYY-MM-DD
+
+## Context
+Describe the problem, constraints, and alternatives.
+
+## Decision
+Describe the chosen option.
+
+## Consequences
+Positive:
+- ...
+
+Negative:
+- ...
+
+## Alternatives considered
+- ...
+
+## Links
+- Issue:
+- PR:

--- a/docs/workflow/ISSUE_TO_PR_WORKFLOW.md
+++ b/docs/workflow/ISSUE_TO_PR_WORKFLOW.md
@@ -1,0 +1,59 @@
+# Issue to PR Workflow
+
+## 1. Create or select an issue
+
+The issue must include:
+
+- Context
+- Problem or goal
+- Scope
+- Acceptance criteria
+- Safety requirements
+- Verification expectations
+
+## 2. Implement on a task branch
+
+Branch naming examples:
+
+```text
+task/<issue-number>-short-name
+fix/<issue-number>-short-name
+docs/<issue-number>-short-name
+```
+
+## 3. Open PR
+
+The PR should include:
+
+- Linked issue using `Closes #<issue-number>`
+- Summary
+- Changed files
+- Test/manual verification
+- Known risks
+
+## 4. Review
+
+Review in chat first.
+
+Official GitHub review actions are used only after explicit instruction:
+
+- APPROVE
+- REQUEST_CHANGES
+- COMMENT
+
+## 5. Merge
+
+Merge only when:
+
+- PR is not draft.
+- PR links the correct issue.
+- Scope matches the issue.
+- No blocking findings remain.
+- Tests/checks/manual verification are clear.
+- No secrets are present.
+
+Example:
+
+```powershell
+.\tools\parsevkctl\parsevkctl.ps1 task merge <issue-number>
+```

--- a/docs/workflow/NOTES_SYSTEM.md
+++ b/docs/workflow/NOTES_SYSTEM.md
@@ -1,0 +1,49 @@
+# parseVK Notes and Task Workflow
+
+## Purpose
+
+This workflow separates raw thinking from executable project work.
+
+## Sources of truth
+
+| Layer | Tool/location | Purpose |
+|---|---|---|
+| Raw notes | private `parsevk-notes-vault` | Ideas, drafts, analysis |
+| Executable task | GitHub Issue | Work that should be implemented |
+| Status | GitHub Project | Backlog and execution state |
+| Implementation | Pull Request | Code changes |
+| Final architecture | `docs/adr/` | Accepted decisions |
+
+## State flow
+
+```text
+raw note → shaped note → GitHub issue → PR → review → merge → docs/ADR if needed
+```
+
+## Rules
+
+1. Do not put raw personal notes in the main repository.
+2. Convert only clear, scoped notes into GitHub Issues.
+3. Every implementation PR should link an issue.
+4. PR review happens in chat first, unless an explicit GitHub review is requested.
+5. Final architectural decisions belong in `docs/adr/`.
+
+## GitHub Project statuses
+
+- Inbox
+- Ready
+- In Progress
+- Review
+- Done
+- Blocked
+
+## Note conversion checklist
+
+Before creating a GitHub Issue from a note:
+
+- [ ] The problem is clear.
+- [ ] The desired result is clear.
+- [ ] Scope is explicit.
+- [ ] Acceptance criteria exist.
+- [ ] Safety requirements exist.
+- [ ] It is not just a vague idea.


### PR DESCRIPTION
## Summary
Adds initial notes/task workflow scaffolding for parseVK:
- GitHub issue templates
- notes system documentation
- issue-to-PR workflow documentation
- ADR template

## Test
Documentation-only change. Verified files are added under `.github/ISSUE_TEMPLATE` and `docs/`.