### PR TITLE
fix(parsevkctl): make merged task branch cleanup idempotent

### DIFF
--- a/docs/workflow/ISSUE_TO_PR_WORKFLOW.md
+++ b/docs/workflow/ISSUE_TO_PR_WORKFLOW.md
@@ -55,5 +55,6 @@ Merge only when:
 Example:
 
 ```powershell
-.\tools\parsevkctl\parsevkctl.ps1 task merge <issue-number>
+cd tools/parsevkctl-go
+go run ./cmd/parsevkctl task merge <issue-number>
 ```

--- a/tools/parsevkctl-go/internal/commands/commands_test.go
+++ b/tools/parsevkctl-go/internal/commands/commands_test.go
@@ -897,6 +897,20 @@ func TestTaskMergeDryRunPlan(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("operations = %#v, want %#v", got, want)
 	}
+	var deleteLocalPayload planner.DeleteLocalBranchPayload
+	for _, operation := range result.Plan.Operations {
+		if operation.Type == planner.OperationBranchDeleteLocal {
+			var ok bool
+			deleteLocalPayload, ok = operation.Payload.(planner.DeleteLocalBranchPayload)
+			if !ok {
+				t.Fatalf("delete local payload type = %T, want planner.DeleteLocalBranchPayload", operation.Payload)
+			}
+			break
+		}
+	}
+	if !deleteLocalPayload.Force {
+		t.Fatalf("delete local payload Force = false, want true for post-merge cleanup")
+	}
 	if result.LocalGate == nil || len(result.LocalGate.Blockers) != 0 {
 		t.Fatalf("local gate = %#v, want clean gate", result.LocalGate)
 	}

--- a/tools/parsevkctl-go/internal/commands/write.go
+++ b/tools/parsevkctl-go/internal/commands/write.go
@@ -491,6 +491,7 @@ func BuildTaskMergePlan(ctx context.Context, input TaskIssueInput) (TaskMergePla
 			return TaskMergePlanResult{}, fmt.Errorf("check remote branch %q: %w", linked.Head, err)
 		}
 	}
+	deleteLocalBranch := mergeDeletesBranch(input.Config) && localBranchExists && linked.Head != ""
 	plan, err := planner.NewMergeTaskPlan(planner.MergeTaskInput{
 		Issue:                  issue,
 		PullRequest:            *linked,
@@ -498,8 +499,8 @@ func BuildTaskMergePlan(ctx context.Context, input TaskIssueInput) (TaskMergePla
 		TargetStatus:           domain.ProjectStatusDone,
 		MergeMethod:            mergeStrategy(input.Config),
 		DeleteRemoteBranch:     false,
-		DeleteLocalBranch:      mergeDeletesBranch(input.Config) && localBranchExists && linked.Head != "",
-		ForceDeleteLocalBranch: input.ForceDeleteLocalBranch,
+		DeleteLocalBranch:      deleteLocalBranch,
+		ForceDeleteLocalBranch: input.ForceDeleteLocalBranch || deleteLocalBranch,
 		DeleteRemoteAfterMerge: mergeDeletesBranch(input.Config) && remoteBranchExists && linked.Head != "",
 		CloseIssue:             true,
 		SyncDefaultBranch:      true,


### PR DESCRIPTION
## Summary
- Implemented changes for issue #225.

## Issue

Closes #225

## Changed Files

- [ ] tools/parsevkctl-go/internal/commands/commands_test.go
- [ ] tools/parsevkctl-go/internal/commands/write.go

## Validation

- [ ] go fmt ./...
- [ ] go test ./...
- [ ] manual validation completed if required

## Risks

- Medium risk: this PR changes parsevkctl workflow behavior.

## AI Workflow

Before merge, run:
- '$parsevk-pr-review'
- '$parsevk-merge-gate'

Do not create GitHub approve from the same user.
