### PR TITLE
refactor(api-gateway): introduce shared internal service client

### DIFF
--- a/services/api-gateway/app/clients/content/client.py
+++ b/services/api-gateway/app/clients/content/client.py
@@ -1,12 +1,12 @@
 from typing import Any
 
 import httpx
-
-from common.headers import CALLER_SERVICE_HEADER, CORRELATION_ID_HEADER, INTERNAL_SERVICE_TOKEN_HEADER, REQUEST_ID_HEADER
-
+from app.clients.internal import (
+    InternalClientHTTPError,
+    InternalClientUnavailableError,
+    InternalServiceClient,
+)
 from app.core.config import settings
-
-USER_ID_HEADER = "X-User-ID"
 
 
 class ContentClientError(Exception):
@@ -26,28 +26,32 @@ class ContentClientUnavailableError(ContentClientError):
 
 class ContentClient:
     def __init__(self, base_url: str | None = None, client: httpx.AsyncClient | None = None):
-        self.base_url = (base_url or settings.content_base_url).rstrip("/")
-        self._client = client or httpx.AsyncClient(
-            base_url=self.base_url,
+        self._internal = InternalServiceClient(
+            service_name="Content",
+            base_url=base_url or settings.content_base_url,
+            internal_token=settings.internal_service_token,
             timeout=httpx.Timeout(timeout=10.0, connect=2.0, read=10.0, write=5.0),
+            client=client,
         )
-        self._owns_client = client is None
+        self.base_url = self._internal.base_url
+        self._client = self._internal._client
+        self._owns_client = self._internal._owns_client
 
     async def close(self) -> None:
-        if self._owns_client:
-            await self._client.aclose()
+        await self._internal.close()
 
-    def _headers(self, *, user_id: str, request_id: str | None, correlation_id: str | None) -> dict[str, str]:
-        headers = {
-            INTERNAL_SERVICE_TOKEN_HEADER: settings.internal_service_token,
-            CALLER_SERVICE_HEADER: "api-gateway",
-            USER_ID_HEADER: user_id,
-        }
-        if request_id:
-            headers[REQUEST_ID_HEADER] = request_id
-        if correlation_id:
-            headers[CORRELATION_ID_HEADER] = correlation_id
-        return headers
+    def _headers(
+        self,
+        *,
+        user_id: str,
+        request_id: str | None,
+        correlation_id: str | None,
+    ) -> dict[str, str]:
+        return self._internal.headers(
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
 
     async def request(
         self,
@@ -61,24 +65,18 @@ class ContentClient:
         json: Any | None = None,
     ) -> Any:
         try:
-            response = await self._client.request(
+            return await self._internal.request(
                 method,
                 path,
-                headers=self._headers(user_id=user_id, request_id=request_id, correlation_id=correlation_id),
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
                 params=params,
                 json=json,
             )
-            response.raise_for_status()
-            if not response.content:
-                return None
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            try:
-                detail: Any = exc.response.json()
-            except ValueError:
-                detail = exc.response.text
-            raise ContentClientHTTPError(status_code=exc.response.status_code, detail=detail) from exc
-        except httpx.RequestError as exc:
+        except InternalClientHTTPError as exc:
+            raise ContentClientHTTPError(status_code=exc.status_code, detail=exc.detail) from exc
+        except InternalClientUnavailableError as exc:
             raise ContentClientUnavailableError("Content service is unavailable") from exc
 
     async def raw_request(
@@ -92,19 +90,15 @@ class ContentClient:
         params: dict | None = None,
     ) -> httpx.Response:
         try:
-            response = await self._client.request(
+            return await self._internal.raw_request(
                 method,
                 path,
-                headers=self._headers(user_id=user_id, request_id=request_id, correlation_id=correlation_id),
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
                 params=params,
             )
-            response.raise_for_status()
-            return response
-        except httpx.HTTPStatusError as exc:
-            try:
-                detail: Any = exc.response.json()
-            except ValueError:
-                detail = exc.response.text
-            raise ContentClientHTTPError(status_code=exc.response.status_code, detail=detail) from exc
-        except httpx.RequestError as exc:
+        except InternalClientHTTPError as exc:
+            raise ContentClientHTTPError(status_code=exc.status_code, detail=exc.detail) from exc
+        except InternalClientUnavailableError as exc:
             raise ContentClientUnavailableError("Content service is unavailable") from exc

--- a/services/api-gateway/app/clients/identity/client.py
+++ b/services/api-gateway/app/clients/identity/client.py
@@ -1,14 +1,6 @@
 from typing import Any
 
 import httpx
-
-from common.headers import (
-    CALLER_SERVICE_HEADER,
-    CORRELATION_ID_HEADER,
-    INTERNAL_SERVICE_TOKEN_HEADER,
-    REQUEST_ID_HEADER,
-)
-
 from app.clients.identity.schemas import (
     IdentityAuthResponse,
     IdentityChangePasswordRequest,
@@ -16,6 +8,11 @@ from app.clients.identity.schemas import (
     IdentityLogoutRequest,
     IdentityRefreshRequest,
     IdentityUser,
+)
+from app.clients.internal import (
+    InternalClientHTTPError,
+    InternalClientUnavailableError,
+    InternalServiceClient,
 )
 from app.core.config import settings
 
@@ -41,39 +38,31 @@ class IdentityClient:
         base_url: str | None = None,
         client: httpx.AsyncClient | None = None,
     ):
-        self.base_url = (base_url or settings.identity_base_url).rstrip("/")
-        self._client = client or httpx.AsyncClient(
-            base_url=self.base_url,
+        self._internal = InternalServiceClient(
+            service_name="Identity",
+            base_url=base_url or settings.identity_base_url,
+            internal_token=settings.internal_service_token,
             timeout=httpx.Timeout(
                 timeout=5.0,
                 connect=2.0,
                 read=5.0,
                 write=5.0,
             ),
+            client=client,
         )
-        self._owns_client = client is None
+        self.base_url = self._internal.base_url
+        self._client = self._internal._client
+        self._owns_client = self._internal._owns_client
 
     async def close(self) -> None:
-        if self._owns_client:
-            await self._client.aclose()
+        await self._internal.close()
 
     def _headers(
         self,
         request_id: str | None,
         correlation_id: str | None,
     ) -> dict[str, str]:
-        headers = {
-            INTERNAL_SERVICE_TOKEN_HEADER: settings.internal_service_token,
-            CALLER_SERVICE_HEADER: "api-gateway",
-        }
-
-        if request_id:
-            headers[REQUEST_ID_HEADER] = request_id
-
-        if correlation_id:
-            headers[CORRELATION_ID_HEADER] = correlation_id
-
-        return headers
+        return self._internal.headers(request_id=request_id, correlation_id=correlation_id)
 
     async def _request(
         self,
@@ -88,7 +77,23 @@ class IdentityClient:
         headers = kwargs.pop("headers", {})
 
         if internal:
-            headers.update(self._headers(request_id, correlation_id))
+            try:
+                return await self._internal.raw_request(
+                    method,
+                    url,
+                    request_id=request_id,
+                    correlation_id=correlation_id,
+                    **kwargs,
+                )
+            except InternalClientHTTPError as exc:
+                raise IdentityClientHTTPError(
+                    status_code=exc.status_code,
+                    detail=exc.detail,
+                ) from exc
+            except InternalClientUnavailableError as exc:
+                raise IdentityClientUnavailableError(
+                    "Identity service is unavailable"
+                ) from exc
 
         try:
             response = await self._client.request(

--- a/services/api-gateway/app/clients/internal.py
+++ b/services/api-gateway/app/clients/internal.py
@@ -1,0 +1,158 @@
+from typing import Any
+
+import httpx
+from common.headers import (
+    CALLER_SERVICE_HEADER,
+    CORRELATION_ID_HEADER,
+    INTERNAL_SERVICE_TOKEN_HEADER,
+    REQUEST_ID_HEADER,
+)
+
+USER_ID_HEADER = "X-User-ID"
+CALLER_SERVICE = "api-gateway"
+
+
+class InternalClientError(Exception):
+    """Base error for internal service client failures."""
+
+
+class InternalClientHTTPError(InternalClientError):
+    def __init__(self, *, service_name: str, status_code: int, detail: Any) -> None:
+        self.service_name = service_name
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"{service_name} service returned HTTP {status_code}")
+
+
+class InternalClientUnavailableError(InternalClientError):
+    def __init__(self, *, service_name: str) -> None:
+        self.service_name = service_name
+        super().__init__(f"{service_name} service is unavailable")
+
+
+class InternalServiceClient:
+    def __init__(
+        self,
+        *,
+        service_name: str,
+        base_url: str,
+        internal_token: str,
+        timeout: httpx.Timeout | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.service_name = service_name
+        self.base_url = base_url.rstrip("/")
+        self.internal_token = internal_token
+        self._client = client or httpx.AsyncClient(base_url=self.base_url, timeout=timeout)
+        self._owns_client = client is None
+
+    async def close(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    def headers(
+        self,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict[str, str]:
+        headers = {
+            INTERNAL_SERVICE_TOKEN_HEADER: self.internal_token,
+            CALLER_SERVICE_HEADER: CALLER_SERVICE,
+        }
+        if user_id is not None:
+            headers[USER_ID_HEADER] = user_id
+        if request_id:
+            headers[REQUEST_ID_HEADER] = request_id
+        if correlation_id:
+            headers[CORRELATION_ID_HEADER] = correlation_id
+        return headers
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+        params: dict | None = None,
+        json: Any | None = None,
+        files: Any | None = None,
+    ) -> Any:
+        response = await self.raw_request(
+            method,
+            path,
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            params=params,
+            json=json,
+            files=files,
+        )
+        if not response.content:
+            return None
+        return response.json()
+
+    async def raw_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+        params: dict | None = None,
+        json: Any | None = None,
+        files: Any | None = None,
+    ) -> httpx.Response:
+        try:
+            response = await self._client.request(
+                method,
+                path,
+                headers=self.headers(
+                    user_id=user_id,
+                    request_id=request_id,
+                    correlation_id=correlation_id,
+                ),
+                params=params,
+                json=json,
+                files=files,
+            )
+            response.raise_for_status()
+            return response
+        except httpx.HTTPStatusError as exc:
+            raise InternalClientHTTPError(
+                service_name=self.service_name,
+                status_code=exc.response.status_code,
+                detail=self._response_detail(exc.response),
+            ) from exc
+        except httpx.RequestError as exc:
+            raise InternalClientUnavailableError(service_name=self.service_name) from exc
+
+    async def get_bytes(
+        self,
+        path: str,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+        params: dict | None = None,
+    ) -> bytes:
+        response = await self.raw_request(
+            "GET",
+            path,
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            params=params,
+        )
+        return response.content
+
+    @staticmethod
+    def _response_detail(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return response.text

--- a/services/api-gateway/app/clients/moderation/client.py
+++ b/services/api-gateway/app/clients/moderation/client.py
@@ -1,10 +1,12 @@
 from typing import Any
+
 import httpx
-
-from common.headers import CALLER_SERVICE_HEADER, CORRELATION_ID_HEADER, INTERNAL_SERVICE_TOKEN_HEADER, REQUEST_ID_HEADER
+from app.clients.internal import (
+    InternalClientHTTPError,
+    InternalClientUnavailableError,
+    InternalServiceClient,
+)
 from app.core.config import settings
-
-USER_ID_HEADER = "X-User-ID"
 
 
 class ModerationClientError(Exception):
@@ -24,28 +26,32 @@ class ModerationClientUnavailableError(ModerationClientError):
 
 class ModerationClient:
     def __init__(self, base_url: str | None = None, client: httpx.AsyncClient | None = None):
-        self.base_url = (base_url or settings.moderation_base_url).rstrip("/")
-        self._client = client or httpx.AsyncClient(
-            base_url=self.base_url,
+        self._internal = InternalServiceClient(
+            service_name="Moderation",
+            base_url=base_url or settings.moderation_base_url,
+            internal_token=settings.internal_service_token,
             timeout=httpx.Timeout(timeout=15.0, connect=2.0, read=15.0, write=5.0),
+            client=client,
         )
-        self._owns_client = client is None
+        self.base_url = self._internal.base_url
+        self._client = self._internal._client
+        self._owns_client = self._internal._owns_client
 
     async def close(self) -> None:
-        if self._owns_client:
-            await self._client.aclose()
+        await self._internal.close()
 
-    def _headers(self, *, user_id: str, request_id: str | None, correlation_id: str | None) -> dict[str, str]:
-        headers = {
-            INTERNAL_SERVICE_TOKEN_HEADER: settings.internal_service_token,
-            CALLER_SERVICE_HEADER: "api-gateway",
-            USER_ID_HEADER: user_id,
-        }
-        if request_id:
-            headers[REQUEST_ID_HEADER] = request_id
-        if correlation_id:
-            headers[CORRELATION_ID_HEADER] = correlation_id
-        return headers
+    def _headers(
+        self,
+        *,
+        user_id: str,
+        request_id: str | None,
+        correlation_id: str | None,
+    ) -> dict[str, str]:
+        return self._internal.headers(
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
 
     async def request(
         self,
@@ -59,22 +65,16 @@ class ModerationClient:
         json: Any | None = None,
     ) -> Any:
         try:
-            response = await self._client.request(
+            return await self._internal.request(
                 method,
                 path,
-                headers=self._headers(user_id=user_id, request_id=request_id, correlation_id=correlation_id),
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
                 params=params,
                 json=json,
             )
-            response.raise_for_status()
-            if not response.content:
-                return None
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            try:
-                detail: Any = exc.response.json()
-            except ValueError:
-                detail = exc.response.text
-            raise ModerationClientHTTPError(status_code=exc.response.status_code, detail=detail) from exc
-        except httpx.RequestError as exc:
+        except InternalClientHTTPError as exc:
+            raise ModerationClientHTTPError(status_code=exc.status_code, detail=exc.detail) from exc
+        except InternalClientUnavailableError as exc:
             raise ModerationClientUnavailableError("Moderation service is unavailable") from exc

--- a/services/api-gateway/app/clients/tasks/client.py
+++ b/services/api-gateway/app/clients/tasks/client.py
@@ -1,17 +1,12 @@
 from typing import Any
 
 import httpx
-
-from common.headers import (
-    CALLER_SERVICE_HEADER,
-    CORRELATION_ID_HEADER,
-    INTERNAL_SERVICE_TOKEN_HEADER,
-    REQUEST_ID_HEADER,
+from app.clients.internal import (
+    InternalClientHTTPError,
+    InternalClientUnavailableError,
+    InternalServiceClient,
 )
-
 from app.core.config import settings
-
-USER_ID_HEADER = "X-User-ID"
 
 
 class TasksClientError(Exception):
@@ -35,16 +30,19 @@ class TasksClient:
         base_url: str | None = None,
         client: httpx.AsyncClient | None = None,
     ):
-        self.base_url = (base_url or settings.tasks_base_url).rstrip("/")
-        self._client = client or httpx.AsyncClient(
-            base_url=self.base_url,
+        self._internal = InternalServiceClient(
+            service_name="Tasks",
+            base_url=base_url or settings.tasks_base_url,
+            internal_token=settings.internal_service_token,
             timeout=httpx.Timeout(timeout=10.0, connect=2.0, read=10.0, write=5.0),
+            client=client,
         )
-        self._owns_client = client is None
+        self.base_url = self._internal.base_url
+        self._client = self._internal._client
+        self._owns_client = self._internal._owns_client
 
     async def close(self) -> None:
-        if self._owns_client:
-            await self._client.aclose()
+        await self._internal.close()
 
     def _headers(
         self,
@@ -53,16 +51,11 @@ class TasksClient:
         request_id: str | None,
         correlation_id: str | None,
     ) -> dict[str, str]:
-        headers = {
-            INTERNAL_SERVICE_TOKEN_HEADER: settings.internal_service_token,
-            CALLER_SERVICE_HEADER: "api-gateway",
-            USER_ID_HEADER: user_id,
-        }
-        if request_id:
-            headers[REQUEST_ID_HEADER] = request_id
-        if correlation_id:
-            headers[CORRELATION_ID_HEADER] = correlation_id
-        return headers
+        return self._internal.headers(
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
 
     async def request(
         self,
@@ -76,26 +69,16 @@ class TasksClient:
         params: dict | None = None,
     ) -> Any:
         try:
-            response = await self._client.request(
+            return await self._internal.request(
                 method,
                 path,
-                headers=self._headers(
-                    user_id=user_id,
-                    request_id=request_id,
-                    correlation_id=correlation_id,
-                ),
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
                 json=json,
                 params=params,
             )
-            response.raise_for_status()
-            if response.status_code == 204:
-                return None
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            try:
-                detail: Any = exc.response.json()
-            except ValueError:
-                detail = exc.response.text
-            raise TasksClientHTTPError(status_code=exc.response.status_code, detail=detail) from exc
-        except httpx.RequestError as exc:
+        except InternalClientHTTPError as exc:
+            raise TasksClientHTTPError(status_code=exc.status_code, detail=exc.detail) from exc
+        except InternalClientUnavailableError as exc:
             raise TasksClientUnavailableError("Tasks service is unavailable") from exc

--- a/services/api-gateway/app/clients/vk_service/client.py
+++ b/services/api-gateway/app/clients/vk_service/client.py
@@ -1,15 +1,12 @@
 from typing import Any
-import httpx
 
-from common.headers import (
-    CALLER_SERVICE_HEADER,
-    CORRELATION_ID_HEADER,
-    INTERNAL_SERVICE_TOKEN_HEADER,
-    REQUEST_ID_HEADER,
+import httpx
+from app.clients.internal import (
+    InternalClientHTTPError,
+    InternalClientUnavailableError,
+    InternalServiceClient,
 )
 from app.core.config import settings
-
-USER_ID_HEADER = "X-User-ID"
 
 
 class VkServiceClientError(Exception):
@@ -28,17 +25,24 @@ class VkServiceClientUnavailableError(VkServiceClientError):
 
 
 class VkServiceClient:
-    def __init__(self, base_url: str | None = None, client: httpx.AsyncClient | None = None) -> None:
-        self.base_url = (base_url or settings.vk_service_base_url).rstrip("/")
-        self._client = client or httpx.AsyncClient(
-            base_url=self.base_url,
+    def __init__(
+        self,
+        base_url: str | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._internal = InternalServiceClient(
+            service_name="VK",
+            base_url=base_url or settings.vk_service_base_url,
+            internal_token=settings.internal_service_token,
             timeout=httpx.Timeout(timeout=30.0, connect=2.0, read=30.0, write=10.0),
+            client=client,
         )
-        self._owns_client = client is None
+        self.base_url = self._internal.base_url
+        self._client = self._internal._client
+        self._owns_client = self._internal._owns_client
 
     async def close(self) -> None:
-        if self._owns_client:
-            await self._client.aclose()
+        await self._internal.close()
 
     def _headers(
         self,
@@ -47,16 +51,11 @@ class VkServiceClient:
         request_id: str | None,
         correlation_id: str | None,
     ) -> dict[str, str]:
-        headers = {
-            INTERNAL_SERVICE_TOKEN_HEADER: settings.internal_service_token,
-            CALLER_SERVICE_HEADER: "api-gateway",
-            USER_ID_HEADER: user_id,
-        }
-        if request_id:
-            headers[REQUEST_ID_HEADER] = request_id
-        if correlation_id:
-            headers[CORRELATION_ID_HEADER] = correlation_id
-        return headers
+        return self._internal.headers(
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
 
     async def request(
         self,
@@ -71,31 +70,21 @@ class VkServiceClient:
         files: Any | None = None,
     ) -> Any:
         try:
-            response = await self._client.request(
+            return await self._internal.request(
                 method,
                 path,
-                headers=self._headers(
-                    user_id=user_id,
-                    request_id=request_id,
-                    correlation_id=correlation_id,
-                ),
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
                 params=params,
                 json=json,
                 files=files,
             )
-            response.raise_for_status()
-            if not response.content:
-                return None
-            return response.json()
-        except httpx.HTTPStatusError as exc:
-            try:
-                detail: Any = exc.response.json()
-            except ValueError:
-                detail = exc.response.text
+        except InternalClientHTTPError as exc:
             raise VkServiceClientHTTPError(
-                status_code=exc.response.status_code, detail=detail
+                status_code=exc.status_code, detail=exc.detail
             ) from exc
-        except httpx.RequestError as exc:
+        except InternalClientUnavailableError as exc:
             raise VkServiceClientUnavailableError("VK service is unavailable") from exc
 
     async def get_xlsx_bytes(
@@ -108,23 +97,15 @@ class VkServiceClient:
         correlation_id: str | None = None,
     ) -> bytes:
         try:
-            response = await self._client.get(
+            return await self._internal.get_bytes(
                 f"/internal/{provider}/friends/jobs/{job_id}/download/xlsx",
-                headers=self._headers(
-                    user_id=user_id,
-                    request_id=request_id,
-                    correlation_id=correlation_id,
-                ),
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
             )
-            response.raise_for_status()
-            return response.content
-        except httpx.HTTPStatusError as exc:
-            try:
-                detail: Any = exc.response.json()
-            except ValueError:
-                detail = exc.response.text
+        except InternalClientHTTPError as exc:
             raise VkServiceClientHTTPError(
-                status_code=exc.response.status_code, detail=detail
+                status_code=exc.status_code, detail=exc.detail
             ) from exc
-        except httpx.RequestError as exc:
+        except InternalClientUnavailableError as exc:
             raise VkServiceClientUnavailableError("VK service is unavailable") from exc

--- a/services/api-gateway/tests/test_internal_client.py
+++ b/services/api-gateway/tests/test_internal_client.py
@@ -1,0 +1,124 @@
+﻿# ruff: noqa: E402
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.modules.pop("_service_path", None)
+
+from _service_path import use_service_path  # noqa: E402
+
+use_service_path()
+
+from app.clients.internal import (
+    InternalClientHTTPError,
+    InternalClientUnavailableError,
+    InternalServiceClient,
+)  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_internal_client_adds_standard_headers_and_parses_json():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["X-Internal-Service-Token"] == "test-token"
+        assert request.headers["X-Caller-Service"] == "api-gateway"
+        assert request.headers["X-User-ID"] == "user-1"
+        assert request.headers["X-Request-ID"] == "request-1"
+        assert request.headers["X-Correlation-ID"] == "correlation-1"
+        assert request.url.path == "/internal/items"
+        assert request.url.params["q"] == "abc"
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    async_client = httpx.AsyncClient(transport=transport, base_url="http://content")
+    client = InternalServiceClient(
+        service_name="Content",
+        base_url="http://content/",
+        internal_token="test-token",  # noqa: S106
+        client=async_client,
+    )
+
+    response = await client.request(
+        "GET",
+        "/internal/items",
+        user_id="user-1",
+        request_id="request-1",
+        correlation_id="correlation-1",
+        params={"q": "abc"},
+    )
+
+    assert response == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_internal_client_returns_none_for_empty_response():
+    transport = httpx.MockTransport(lambda request: httpx.Response(204))
+    async_client = httpx.AsyncClient(transport=transport, base_url="http://tasks")
+    client = InternalServiceClient(
+        service_name="Tasks",
+        base_url="http://tasks",
+        internal_token="test-token",  # noqa: S106
+        client=async_client,
+    )
+
+    response = await client.request("DELETE", "/internal/tasks/1", user_id="user-1")
+
+    assert response is None
+
+
+@pytest.mark.asyncio
+async def test_internal_client_raises_http_error_with_json_detail():
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(409, json={"detail": "conflict"})
+    )
+    async_client = httpx.AsyncClient(transport=transport, base_url="http://tasks")
+    client = InternalServiceClient(
+        service_name="Tasks",
+        base_url="http://tasks",
+        internal_token="test-token",  # noqa: S106
+        client=async_client,
+    )
+
+    with pytest.raises(InternalClientHTTPError) as exc_info:
+        await client.request("POST", "/internal/tasks", user_id="user-1")
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == {"detail": "conflict"}
+    assert str(exc_info.value) == "Tasks service returned HTTP 409"
+
+
+@pytest.mark.asyncio
+async def test_internal_client_raises_unavailable_error_for_request_failure():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    async_client = httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="http://tasks")
+    client = InternalServiceClient(
+        service_name="Tasks",
+        base_url="http://tasks",
+        internal_token="test-token",  # noqa: S106
+        client=async_client,
+    )
+
+    with pytest.raises(InternalClientUnavailableError) as exc_info:
+        await client.request("GET", "/internal/tasks", user_id="user-1")
+
+    assert str(exc_info.value) == "Tasks service is unavailable"
+
+
+@pytest.mark.asyncio
+async def test_internal_client_raw_request_returns_response_bytes():
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, content=b"xlsx-bytes"))
+    async_client = httpx.AsyncClient(transport=transport, base_url="http://content")
+    client = InternalServiceClient(
+        service_name="Content",
+        base_url="http://content",
+        internal_token="test-token",  # noqa: S106
+        client=async_client,
+    )
+
+    response = await client.raw_request("GET", "/internal/download", user_id="user-1")
+
+    assert response.content == b"xlsx-bytes"


### PR DESCRIPTION
Closes #242

## Summary
- Add a shared `InternalServiceClient` foundation for api-gateway service-to-service calls.
- Move content, identity, moderation, tasks, and vk-service typed clients onto the shared request/header/error handling.
- Add focused tests for internal headers, correlation/request IDs, JSON and no-content responses, HTTP error mapping, and network unavailable mapping.

## Validation
- [x] `python -m pytest tests/test_internal_client.py` — 5 passed
- [x] `uv run --with ruff ruff check app/clients/internal.py app/clients/content/client.py app/clients/moderation/client.py app/clients/tasks/client.py app/clients/vk_service/client.py app/clients/identity/client.py tests/test_internal_client.py` — passed
- [x] `uv run --extra test python -m pytest tests/test_internal_client.py tests/test_content_gateway.py tests/test_tasks_gateway.py tests/test_auth_gateway.py tests/test_jwt_validation.py tests/test_vk_friends_adapter.py tests/test_ok_friends_adapter.py tests/test_redaction_gateway.py tests/test_photo_analysis_gateway.py` — 37 passed
- [x] `python .agents\skills\parsevk-service-architecture\scripts\validate-service.py --no-db services\api-gateway` — 28 passed

## Notes
- Public typed client method signatures are preserved.
- No frontend, deployment, Docker, environment, or external API contract changes are included.