### PR TITLE
refactor(api-gateway): route comments watchlist keywords through typed clients

### DIFF
--- a/services/api-gateway/app/modules/comments/router.py
+++ b/services/api-gateway/app/modules/comments/router.py
@@ -1,25 +1,43 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, Query
-
 from app.core.security import require_auth
+from app.modules.auth.router import request_ids
 from app.modules.comments.service import CommentsGatewayService, get_comments_gateway_service
+from fastapi import APIRouter, Body, Depends, Query, Request
 
-router = APIRouter(prefix="/api/v1/comments", tags=["comments"], dependencies=[Depends(require_auth)])
+router = APIRouter(prefix="/api/v1/comments", tags=["comments"])
+
+LIST_OFFSET_QUERY = Query(default=0, ge=0)
+LIST_LIMIT_QUERY = Query(default=20, ge=1, le=100)
+LIST_KEYWORDS_QUERY = Query(default=None)
+LIST_KEYWORD_SOURCE_QUERY = Query(default=None)
+LIST_READ_STATUS_QUERY = Query(default=None)
+LIST_SEARCH_QUERY = Query(default=None)
+CURSOR_QUERY = Query(default=None)
+CURSOR_LIMIT_QUERY = Query(default=20, ge=1, le=100)
+CURSOR_KEYWORDS_QUERY = Query(default=None)
+CURSOR_KEYWORD_SOURCE_QUERY = Query(default=None)
+CURSOR_READ_STATUS_QUERY = Query(default=None)
+CURSOR_SEARCH_QUERY = Query(default=None)
+AUTH_DEPENDENCY = Depends(require_auth)
+SERVICE_DEPENDENCY = Depends(get_comments_gateway_service)
 
 
 @router.get("")
 async def list_comments(
-    offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=20, ge=1, le=100),
-    keywords: list[str] | None = Query(default=None),
-    keywordSource: str | None = Query(default=None),
-    readStatus: str | None = Query(default=None),
-    search: str | None = Query(default=None),
-    service: CommentsGatewayService = Depends(get_comments_gateway_service),
+    request: Request,
+    offset: int = LIST_OFFSET_QUERY,
+    limit: int = LIST_LIMIT_QUERY,
+    keywords: list[str] | None = LIST_KEYWORDS_QUERY,
+    keywordSource: str | None = LIST_KEYWORD_SOURCE_QUERY,
+    readStatus: str | None = LIST_READ_STATUS_QUERY,
+    search: str | None = LIST_SEARCH_QUERY,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: CommentsGatewayService = SERVICE_DEPENDENCY,
 ):
     # offset -> page conversion: gateway converts frontend offset to internal page
     page = (offset // limit) + 1
+    request_id, correlation_id = request_ids(request)
     return await service.get_comments(
         page=page,
         limit=limit,
@@ -27,19 +45,25 @@ async def list_comments(
         keyword_source=keywordSource,
         read_status=readStatus,
         search=search,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
     )
 
 
 @router.get("/cursor")
 async def list_comments_cursor(
-    cursor: str | None = Query(default=None),
-    limit: int = Query(default=20, ge=1, le=100),
-    keywords: list[str] | None = Query(default=None),
-    keywordSource: str | None = Query(default=None),
-    readStatus: str | None = Query(default=None),
-    search: str | None = Query(default=None),
-    service: CommentsGatewayService = Depends(get_comments_gateway_service),
+    request: Request,
+    cursor: str | None = CURSOR_QUERY,
+    limit: int = CURSOR_LIMIT_QUERY,
+    keywords: list[str] | None = CURSOR_KEYWORDS_QUERY,
+    keywordSource: str | None = CURSOR_KEYWORD_SOURCE_QUERY,
+    readStatus: str | None = CURSOR_READ_STATUS_QUERY,
+    search: str | None = CURSOR_SEARCH_QUERY,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: CommentsGatewayService = SERVICE_DEPENDENCY,
 ):
+    request_id, correlation_id = request_ids(request)
     return await service.get_comments_cursor(
         cursor=cursor,
         limit=limit,
@@ -47,21 +71,41 @@ async def list_comments_cursor(
         keyword_source=keywordSource,
         read_status=readStatus,
         search=search,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
     )
 
 
 @router.patch("/{id}/read")
 async def update_read_status(
+    request: Request,
     id: int,
     payload: Annotated[dict, Body()],
-    service: CommentsGatewayService = Depends(get_comments_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: CommentsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.patch_read_status(id, payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.patch_read_status(
+        id,
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/search")
 async def search_comments(
+    request: Request,
     payload: Annotated[dict, Body()],
-    service: CommentsGatewayService = Depends(get_comments_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: CommentsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.search_comments(payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.search_comments(
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )

--- a/services/api-gateway/app/modules/comments/service.py
+++ b/services/api-gateway/app/modules/comments/service.py
@@ -1,14 +1,26 @@
-import httpx
-from fastapi import HTTPException
+from typing import Any
 
-from app.core.config import settings
+from app.clients.content.client import (
+    ContentClient,
+    ContentClientHTTPError,
+    ContentClientUnavailableError,
+)
+from app.clients.moderation.client import (
+    ModerationClient,
+    ModerationClientHTTPError,
+    ModerationClientUnavailableError,
+)
+from fastapi import HTTPException, status
 
 
 class CommentsGatewayService:
-    def __init__(self):
-        self.moderation_url = settings.moderation_base_url
-        self.content_url = settings.content_base_url
-        self.headers = {"X-Internal-Service-Token": settings.internal_service_token}
+    def __init__(
+        self,
+        moderation_client: ModerationClient | None = None,
+        content_client: ContentClient | None = None,
+    ):
+        self.moderation_client = moderation_client or ModerationClient()
+        self.content_client = content_client or ContentClient()
 
     # ------------------------------------------------------------------ #
     #  Public methods                                                      #
@@ -22,6 +34,9 @@ class CommentsGatewayService:
         keyword_source: str | None = None,
         read_status: str | None = None,
         search: str | None = None,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
     ) -> dict:
         params: dict = {"page": page, "limit": limit}
         if read_status:
@@ -34,16 +49,21 @@ class CommentsGatewayService:
             # httpx accepts list values for multi-value params
             params["keywords"] = keywords
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.moderation_url}/internal/moderation/comments",
-                params=params,
-                headers=self.headers,
-            )
-            resp.raise_for_status()
-            raw = resp.json()
+        raw = await self._moderation_request(
+            "GET",
+            "/internal/moderation/comments",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            params=params,
+        )
 
-        items = await self._enrich_comments(raw["items"])
+        items = await self._enrich_comments(
+            raw["items"],
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return {
             "items": items,
             "total": raw["total"],
@@ -60,6 +80,9 @@ class CommentsGatewayService:
         keyword_source: str | None = None,
         read_status: str | None = None,
         search: str | None = None,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
     ) -> dict:
         params: dict = {"limit": limit}
         if cursor:
@@ -72,16 +95,21 @@ class CommentsGatewayService:
         if keywords:
             params["keywords"] = keywords
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.moderation_url}/internal/moderation/comments/cursor",
-                params=params,
-                headers=self.headers,
-            )
-            resp.raise_for_status()
-            raw = resp.json()
+        raw = await self._moderation_request(
+            "GET",
+            "/internal/moderation/comments/cursor",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            params=params,
+        )
 
-        items = await self._enrich_comments(raw["items"])
+        items = await self._enrich_comments(
+            raw["items"],
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return {
             "items": items,
             "nextCursor": raw["next_cursor"],
@@ -91,7 +119,15 @@ class CommentsGatewayService:
             "unreadCount": raw["unread_count"],
         }
 
-    async def patch_read_status(self, id: int, payload: dict) -> dict:
+    async def patch_read_status(
+        self,
+        id: int,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         # Adapt camelCase frontend payload to snake_case internal payload
         is_read = payload.get("isRead")
         if is_read is None:
@@ -101,19 +137,31 @@ class CommentsGatewayService:
         if not isinstance(is_read, bool):
             raise HTTPException(status_code=422, detail="isRead field must be a boolean")
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.patch(
-                f"{self.moderation_url}/internal/moderation/comments/{id}/read",
-                json={"is_read": is_read},
-                headers=self.headers,
-            )
-            resp.raise_for_status()
-            item = resp.json()
+        item = await self._moderation_request(
+            "PATCH",
+            f"/internal/moderation/comments/{id}/read",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            json={"is_read": is_read},
+        )
 
-        enriched = await self._enrich_comments([item])
+        enriched = await self._enrich_comments(
+            [item],
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return enriched[0] if enriched else item
 
-    async def search_comments(self, payload: dict) -> dict:
+    async def search_comments(
+        self,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         """Fallback search via moderation-service.
 
         Maps frontend CommentsSearchRequestDto to moderation-service query params.
@@ -137,14 +185,14 @@ class CommentsGatewayService:
         if read_status and read_status != "all":
             params["readStatus"] = read_status
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.moderation_url}/internal/moderation/comments",
-                params=params,
-                headers=self.headers,
-            )
-            resp.raise_for_status()
-            raw = resp.json()
+        raw = await self._moderation_request(
+            "GET",
+            "/internal/moderation/comments",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            params=params,
+        )
 
         raw_items = raw.get("items", [])
         total = raw.get("total", len(raw_items))
@@ -168,9 +216,10 @@ class CommentsGatewayService:
     # ------------------------------------------------------------------ #
 
     def _format_comment_search_item(self, item: dict, query: str) -> dict:
-        highlight: list[str] = [query] if query and item.get("text") and query.lower() in item["text"].lower() else []
+        highlight: list[str] = []
+        if query and item.get("text") and query.lower() in item["text"].lower():
+            highlight = [query]
         parts = (item.get("external_key") or "").split(":")
-        comment_id = int(parts[2]) if len(parts) > 2 else None
         post_id = int(parts[1]) if len(parts) > 1 else None
         return {
             "type": "comment",
@@ -204,34 +253,102 @@ class CommentsGatewayService:
 
         return [posts[k] for k in order]
 
-    async def _enrich_comments(self, items: list[dict]) -> list[dict]:
+    async def _moderation_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+        params: dict | None = None,
+        json: Any | None = None,
+    ) -> dict:
+        try:
+            return await self.moderation_client.request(
+                method,
+                path,
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
+                params=params,
+                json=json,
+            )
+        except ModerationClientHTTPError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+        except ModerationClientUnavailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Moderation service unavailable",
+            ) from exc
+
+    async def _content_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+        json: Any | None = None,
+    ) -> Any:
+        try:
+            return await self.content_client.request(
+                method,
+                path,
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
+                json=json,
+            )
+        except ContentClientHTTPError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+        except ContentClientUnavailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Content service unavailable",
+            ) from exc
+
+    async def _enrich_comments(
+        self,
+        items: list[dict],
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> list[dict]:
         if not items:
             return items
 
         author_vk_ids = list({item["author_vk_id"] for item in items if item.get("author_vk_id")})
-        post_external_keys = list({item["post_external_key"] for item in items if item.get("post_external_key")})
+        post_external_keys = list(
+            {item["post_external_key"] for item in items if item.get("post_external_key")}
+        )
 
         authors_dict: dict = {}
         posts_dict: dict = {}
 
-        async with httpx.AsyncClient() as client:
-            if author_vk_ids:
-                author_resp = await client.post(
-                    f"{self.content_url}/internal/content/authors/bulk",
-                    json=author_vk_ids,
-                    headers=self.headers,
-                )
-                if author_resp.status_code == 200:
-                    authors_dict = {a["vkAuthorId"]: a for a in author_resp.json()}
+        if author_vk_ids:
+            authors = await self._content_request(
+                "POST",
+                "/internal/content/authors/bulk",
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
+                json=author_vk_ids,
+            )
+            authors_dict = {a["vkAuthorId"]: a for a in authors}
 
-            if post_external_keys:
-                post_resp = await client.post(
-                    f"{self.content_url}/internal/content/posts/bulk",
-                    json=post_external_keys,
-                    headers=self.headers,
-                )
-                if post_resp.status_code == 200:
-                    posts_dict = {p["externalKey"]: p for p in post_resp.json()}
+        if post_external_keys:
+            posts = await self._content_request(
+                "POST",
+                "/internal/content/posts/bulk",
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
+                json=post_external_keys,
+            )
+            posts_dict = {p["externalKey"]: p for p in posts}
 
         enriched_items = []
         for item in items:

--- a/services/api-gateway/app/modules/keywords/router.py
+++ b/services/api-gateway/app/modules/keywords/router.py
@@ -1,132 +1,263 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, Query, File, UploadFile
-
 from app.core.security import require_auth
+from app.modules.auth.router import request_ids
 from app.modules.keywords.service import KeywordsGatewayService, get_keywords_gateway_service
+from fastapi import APIRouter, Body, Depends, File, Query, Request, UploadFile
 
-router = APIRouter(prefix="/api/v1/keywords", tags=["keywords"], dependencies=[Depends(require_auth)])
+router = APIRouter(prefix="/api/v1/keywords", tags=["keywords"])
+
+PAGE_QUERY = Query(default=1, ge=1)
+LIMIT_QUERY = Query(default=50, ge=1, le=100)
+SEARCH_QUERY = Query(default=None)
+UPLOAD_FILE = File(...)
+AUTH_DEPENDENCY = Depends(require_auth)
+SERVICE_DEPENDENCY = Depends(get_keywords_gateway_service)
 
 
 @router.get("")
 async def get_keywords(
-    page: int = Query(default=1, ge=1),
-    limit: int = Query(default=50, ge=1, le=100),
-    search: str | None = Query(default=None),
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    request: Request,
+    page: int = PAGE_QUERY,
+    limit: int = LIMIT_QUERY,
+    search: str | None = SEARCH_QUERY,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.get_all_keywords(page=page, limit=limit, search=search)
+    request_id, correlation_id = request_ids(request)
+    return await service.get_all_keywords(
+        page=page,
+        limit=limit,
+        search=search,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/add")
 async def add_keyword(
+    request: Request,
     payload: Annotated[dict, Body()],
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.add_keyword(payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.add_keyword(
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/bulk-add")
 async def bulk_add_keywords(
+    request: Request,
     payload: Annotated[dict, Body()],
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.bulk_add_keywords(payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.bulk_add_keywords(
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/upload")
 async def upload_keywords(
-    file: UploadFile = File(...),
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    request: Request,
+    file: UploadFile = UPLOAD_FILE,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.upload_keywords(file)
+    request_id, correlation_id = request_ids(request)
+    return await service.upload_keywords(
+        file,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.patch("/{id}")
 async def update_keyword_category(
+    request: Request,
     id: int,
     payload: Annotated[dict, Body()],
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.update_keyword_category(id, payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.update_keyword_category(
+        id,
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.delete("/all")
 async def delete_all_keywords(
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    request: Request,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.delete_all_keywords()
+    request_id, correlation_id = request_ids(request)
+    return await service.delete_all_keywords(
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.delete("/{id}")
 async def delete_keyword(
+    request: Request,
     id: int,
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.delete_keyword(id)
+    request_id, correlation_id = request_ids(request)
+    return await service.delete_keyword(
+        id,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.get("/{id}/forms")
 async def get_keyword_forms(
+    request: Request,
     id: int,
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.get_keyword_forms(id)
+    request_id, correlation_id = request_ids(request)
+    return await service.get_keyword_forms(
+        id,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/{id}/forms/manual")
 async def add_manual_keyword_form(
+    request: Request,
     id: int,
     payload: Annotated[dict, Body()],
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.add_manual_keyword_form(id, payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.add_manual_keyword_form(
+        id,
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.delete("/{id}/forms/manual")
 async def remove_manual_keyword_form(
+    request: Request,
     id: int,
     payload: Annotated[dict, Body()],
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.remove_manual_keyword_form(id, payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.remove_manual_keyword_form(
+        id,
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/{id}/forms/exclusions")
 async def add_keyword_form_exclusion(
+    request: Request,
     id: int,
     payload: Annotated[dict, Body()],
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.add_keyword_form_exclusion(id, payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.add_keyword_form_exclusion(
+        id,
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.delete("/{id}/forms/exclusions")
 async def remove_keyword_form_exclusion(
+    request: Request,
     id: int,
     payload: Annotated[dict, Body()],
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.remove_keyword_form_exclusion(id, payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.remove_keyword_form_exclusion(
+        id,
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/recalculate-matches")
 async def recalculate_keyword_matches(
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    request: Request,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.recalculate_keyword_matches()
+    request_id, correlation_id = request_ids(request)
+    return await service.recalculate_keyword_matches(
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.get("/recalculation-jobs/{id}")
 async def get_recalculation_job_status(
+    request: Request,
     id: int,
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.get_recalculation_job_status(id)
+    request_id, correlation_id = request_ids(request)
+    return await service.get_recalculation_job_status(
+        id,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/rebuild-forms")
 async def rebuild_keyword_forms(
-    service: KeywordsGatewayService = Depends(get_keywords_gateway_service),
+    request: Request,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: KeywordsGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.rebuild_keyword_forms()
+    request_id, correlation_id = request_ids(request)
+    return await service.rebuild_keyword_forms(
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )

--- a/services/api-gateway/app/modules/keywords/service.py
+++ b/services/api-gateway/app/modules/keywords/service.py
@@ -1,32 +1,51 @@
-import httpx
-from fastapi import HTTPException, UploadFile, status
+from typing import Any
 
-from app.core.config import settings
+from app.clients.moderation.client import (
+    ModerationClient,
+    ModerationClientHTTPError,
+    ModerationClientUnavailableError,
+)
+from fastapi import HTTPException, UploadFile, status
 
 
 class KeywordsGatewayService:
-    def __init__(self):
-        self.moderation_url = settings.moderation_base_url
-        self.headers = {"X-Internal-Service-Token": settings.internal_service_token}
+    def __init__(self, moderation_client: ModerationClient | None = None):
+        self.moderation_client = moderation_client or ModerationClient()
+        self.moderation_url = self.moderation_client.base_url
 
-    async def _request(self, method: str, path: str, **kwargs) -> dict:
-        url = f"{self.moderation_url}{path}"
-        async with httpx.AsyncClient() as client:
-            try:
-                resp = await client.request(method, url, headers=self.headers, **kwargs)
-                resp.raise_for_status()
-                return resp.json()
-            except httpx.HTTPStatusError as e:
-                try:
-                    detail = e.response.json().get("detail", str(e))
-                except Exception:
-                    detail = e.response.text or str(e)
-                raise HTTPException(status_code=e.response.status_code, detail=detail)
-            except httpx.RequestError as e:
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail=f"Moderation service unavailable: {str(e)}"
-                )
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+        params: dict | None = None,
+        json: Any | None = None,
+    ) -> dict:
+        try:
+            return await self.moderation_client.request(
+                method,
+                path,
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
+                params=params,
+                json=json,
+            )
+        except ModerationClientHTTPError as exc:
+            detail = (
+                exc.detail.get("detail", exc.detail)
+                if isinstance(exc.detail, dict)
+                else exc.detail
+            )
+            raise HTTPException(status_code=exc.status_code, detail=detail) from exc
+        except ModerationClientUnavailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Moderation service unavailable",
+            ) from exc
 
     def _format_job(self, job: dict) -> dict:
         return {
@@ -50,12 +69,28 @@ class KeywordsGatewayService:
             "updatedAt": kw.get("updated_at"),
         }
 
-    async def get_all_keywords(self, page: int, limit: int, search: str | None = None) -> dict:
+    async def get_all_keywords(
+        self,
+        page: int,
+        limit: int,
+        search: str | None = None,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         params = {"page": page, "limit": limit}
         if search:
             params["search"] = search
 
-        raw = await self._request("GET", "/internal/moderation/keywords", params=params)
+        raw = await self._request(
+            "GET",
+            "/internal/moderation/keywords",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            params=params,
+        )
         return {
             "keywords": [self._format_keyword(kw) for kw in raw["keywords"]],
             "total": raw["total"],
@@ -63,20 +98,44 @@ class KeywordsGatewayService:
             "limit": raw["limit"],
         }
 
-    async def add_keyword(self, payload: dict) -> dict:
+    async def add_keyword(
+        self,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         # Адаптация camelCase фронтенда к snake_case бэкенда
         body = {
             "word": payload.get("word"),
             "category": payload.get("category"),
             "is_phrase": payload.get("isPhrase", False),
         }
-        raw = await self._request("POST", "/internal/moderation/keywords/add", json=body)
+        raw = await self._request(
+            "POST",
+            "/internal/moderation/keywords/add",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            json=body,
+        )
         return self._format_keyword(raw)
 
-    async def bulk_add_keywords(self, payload: dict) -> dict:
+    async def bulk_add_keywords(
+        self,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         raw = await self._request(
             "POST",
             "/internal/moderation/keywords/bulk-add",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
             json={"words": payload.get("words", [])},
         )
         return {
@@ -89,7 +148,14 @@ class KeywordsGatewayService:
             "updatedCount": raw["stats"]["updated"],
         }
 
-    async def upload_keywords(self, file: UploadFile) -> dict:
+    async def upload_keywords(
+        self,
+        file: UploadFile,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         # Валидация пустого файла и размера (до 5 МБ)
         if not file.filename:
             raise HTTPException(
@@ -112,15 +178,18 @@ class KeywordsGatewayService:
 
         try:
             content_str = contents.decode("utf-8")
-        except UnicodeDecodeError:
+        except UnicodeDecodeError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="File encoding must be UTF-8",
-            )
+            ) from exc
 
         raw = await self._request(
             "POST",
             "/internal/moderation/keywords/upload-content",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
             json={"content": content_str},
         )
         return {
@@ -133,25 +202,74 @@ class KeywordsGatewayService:
             "updatedCount": raw["stats"]["updated"],
         }
 
-    async def update_keyword_category(self, id: int, payload: dict) -> dict:
+    async def update_keyword_category(
+        self,
+        id: int,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         raw = await self._request(
             "PATCH",
             f"/internal/moderation/keywords/{id}",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
             json={"category": payload.get("category")},
         )
         return self._format_keyword(raw)
 
-    async def delete_all_keywords(self) -> dict:
-        raw = await self._request("DELETE", "/internal/moderation/keywords/all")
+    async def delete_all_keywords(
+        self,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        raw = await self._request(
+            "DELETE",
+            "/internal/moderation/keywords/all",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         # Мапим count для фронтенда IDeleteResponse
         return {"count": raw.get("count", 0)}
 
-    async def delete_keyword(self, id: int) -> dict:
-        raw = await self._request("DELETE", f"/internal/moderation/keywords/{id}")
+    async def delete_keyword(
+        self,
+        id: int,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        raw = await self._request(
+            "DELETE",
+            f"/internal/moderation/keywords/{id}",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return self._format_keyword(raw)
 
-    async def get_keyword_forms(self, id: int) -> dict:
-        raw = await self._request("GET", f"/internal/moderation/keywords/{id}/forms")
+    async def get_keyword_forms(
+        self,
+        id: int,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        raw = await self._request(
+            "GET",
+            f"/internal/moderation/keywords/{id}/forms",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return {
             "keywordId": raw["keyword_id"],
             "word": raw["word"],
@@ -161,10 +279,21 @@ class KeywordsGatewayService:
             "exclusions": raw["exclusions"],
         }
 
-    async def add_manual_keyword_form(self, id: int, payload: dict) -> dict:
+    async def add_manual_keyword_form(
+        self,
+        id: int,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         raw = await self._request(
             "POST",
             f"/internal/moderation/keywords/{id}/forms/manual",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
             json={"form": payload.get("form")},
         )
         return {
@@ -176,10 +305,21 @@ class KeywordsGatewayService:
             "exclusions": raw["exclusions"],
         }
 
-    async def remove_manual_keyword_form(self, id: int, payload: dict) -> dict:
+    async def remove_manual_keyword_form(
+        self,
+        id: int,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         raw = await self._request(
             "DELETE",
             f"/internal/moderation/keywords/{id}/forms/manual",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
             json={"form": payload.get("form")},
         )
         return {
@@ -191,10 +331,21 @@ class KeywordsGatewayService:
             "exclusions": raw["exclusions"],
         }
 
-    async def add_keyword_form_exclusion(self, id: int, payload: dict) -> dict:
+    async def add_keyword_form_exclusion(
+        self,
+        id: int,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         raw = await self._request(
             "POST",
             f"/internal/moderation/keywords/{id}/forms/exclusions",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
             json={"form": payload.get("form")},
         )
         return {
@@ -206,10 +357,21 @@ class KeywordsGatewayService:
             "exclusions": raw["exclusions"],
         }
 
-    async def remove_keyword_form_exclusion(self, id: int, payload: dict) -> dict:
+    async def remove_keyword_form_exclusion(
+        self,
+        id: int,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         raw = await self._request(
             "DELETE",
             f"/internal/moderation/keywords/{id}/forms/exclusions",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
             json={"form": payload.get("form")},
         )
         return {
@@ -221,8 +383,20 @@ class KeywordsGatewayService:
             "exclusions": raw["exclusions"],
         }
 
-    async def recalculate_keyword_matches(self) -> dict:
-        raw = await self._request("POST", "/internal/moderation/keywords/recalculate-matches")
+    async def recalculate_keyword_matches(
+        self,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        raw = await self._request(
+            "POST",
+            "/internal/moderation/keywords/recalculate-matches",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return {
             "processed": raw.get("processed", 0),
             "updated": raw.get("updated", 0),
@@ -230,12 +404,37 @@ class KeywordsGatewayService:
             "deleted": raw.get("deleted", 0),
         }
 
-    async def get_recalculation_job_status(self, id: int) -> dict:
-        raw = await self._request("GET", f"/internal/moderation/keywords/recalculation-jobs/{id}")
+    async def get_recalculation_job_status(
+        self,
+        id: int,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        raw = await self._request(
+            "GET",
+            f"/internal/moderation/keywords/recalculation-jobs/{id}",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return self._format_job(raw)
 
-    async def rebuild_keyword_forms(self) -> dict:
-        raw = await self._request("POST", "/internal/moderation/keywords/rebuild-forms")
+    async def rebuild_keyword_forms(
+        self,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        raw = await self._request(
+            "POST",
+            "/internal/moderation/keywords/rebuild-forms",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return {
             "keywordsRebuilt": raw.get("keywords_rebuilt", 0),
             "processed": raw.get("processed", 0),

--- a/services/api-gateway/app/modules/watchlist/router.py
+++ b/services/api-gateway/app/modules/watchlist/router.py
@@ -1,70 +1,135 @@
 from typing import Annotated
-from fastapi import APIRouter, Body, Depends, Query
 
 from app.core.security import require_auth
+from app.modules.auth.router import request_ids
 from app.modules.watchlist.service import WatchlistGatewayService, get_watchlist_gateway_service
+from fastapi import APIRouter, Body, Depends, Query, Request
 
 router = APIRouter(
     prefix="/api/v1/watchlist",
     tags=["watchlist"],
-    dependencies=[Depends(require_auth)],
 )
+
+OFFSET_QUERY = Query(default=0, ge=0)
+LIMIT_QUERY = Query(default=20, ge=1, le=100)
+EXCLUDE_STOPPED_QUERY = Query(default=True)
+AUTH_DEPENDENCY = Depends(require_auth)
+SERVICE_DEPENDENCY = Depends(get_watchlist_gateway_service)
 
 
 @router.get("/authors")
 async def list_authors(
-    offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=20, ge=1, le=100),
-    excludeStopped: bool = Query(default=True),
-    service: WatchlistGatewayService = Depends(get_watchlist_gateway_service),
+    request: Request,
+    offset: int = OFFSET_QUERY,
+    limit: int = LIMIT_QUERY,
+    excludeStopped: bool = EXCLUDE_STOPPED_QUERY,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: WatchlistGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.get_authors(offset=offset, limit=limit, exclude_stopped=excludeStopped)
+    request_id, correlation_id = request_ids(request)
+    return await service.get_authors(
+        offset=offset,
+        limit=limit,
+        exclude_stopped=excludeStopped,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/authors")
 async def create_author(
+    request: Request,
     payload: Annotated[dict, Body()],
-    service: WatchlistGatewayService = Depends(get_watchlist_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: WatchlistGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.create_author(payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.create_author(
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.get("/authors/{id}")
 async def get_author_details(
+    request: Request,
     id: int,
-    offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=20, ge=1, le=100),
-    service: WatchlistGatewayService = Depends(get_watchlist_gateway_service),
+    offset: int = OFFSET_QUERY,
+    limit: int = LIMIT_QUERY,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: WatchlistGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.get_author_details(id=id, offset=offset, limit=limit)
+    request_id, correlation_id = request_ids(request)
+    return await service.get_author_details(
+        id=id,
+        offset=offset,
+        limit=limit,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.patch("/authors/{id}")
 async def update_author(
+    request: Request,
     id: int,
     payload: Annotated[dict, Body()],
-    service: WatchlistGatewayService = Depends(get_watchlist_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: WatchlistGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.update_author(id=id, payload=payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.update_author(
+        id=id,
+        payload=payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.get("/settings")
 async def get_settings(
-    service: WatchlistGatewayService = Depends(get_watchlist_gateway_service),
+    request: Request,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: WatchlistGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.get_settings()
+    request_id, correlation_id = request_ids(request)
+    return await service.get_settings(
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.patch("/settings")
 async def update_settings(
+    request: Request,
     payload: Annotated[dict, Body()],
-    service: WatchlistGatewayService = Depends(get_watchlist_gateway_service),
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: WatchlistGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.update_settings(payload)
+    request_id, correlation_id = request_ids(request)
+    return await service.update_settings(
+        payload,
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )
 
 
 @router.post("/refresh")
 async def manual_refresh(
-    service: WatchlistGatewayService = Depends(get_watchlist_gateway_service),
+    request: Request,
+    auth_claims: dict = AUTH_DEPENDENCY,
+    service: WatchlistGatewayService = SERVICE_DEPENDENCY,
 ):
-    return await service.manual_refresh()
+    request_id, correlation_id = request_ids(request)
+    return await service.manual_refresh(
+        user_id=str(auth_claims["sub"]),
+        request_id=request_id,
+        correlation_id=correlation_id,
+    )

--- a/services/api-gateway/app/modules/watchlist/service.py
+++ b/services/api-gateway/app/modules/watchlist/service.py
@@ -1,51 +1,92 @@
-import httpx
-from fastapi import HTTPException
+from typing import Any
 
-from app.core.config import settings
+from app.clients.content.client import (
+    ContentClient,
+    ContentClientHTTPError,
+    ContentClientUnavailableError,
+)
+from app.clients.moderation.client import (
+    ModerationClient,
+    ModerationClientHTTPError,
+    ModerationClientUnavailableError,
+)
+from fastapi import HTTPException, status
 
 
 class WatchlistGatewayService:
-    def __init__(self):
-        self.moderation_url = settings.moderation_base_url
-        self.content_url = settings.content_base_url
-        self.headers = {"X-Internal-Service-Token": settings.internal_service_token}
+    def __init__(
+        self,
+        moderation_client: ModerationClient | None = None,
+        content_client: ContentClient | None = None,
+    ):
+        self.moderation_client = moderation_client or ModerationClient()
+        self.content_client = content_client or ContentClient()
+        self.moderation_url = self.moderation_client.base_url
+        self.content_url = self.content_client.base_url
 
-    async def get_authors(self, offset: int, limit: int, exclude_stopped: bool) -> dict:
+    async def get_authors(
+        self,
+        offset: int,
+        limit: int,
+        exclude_stopped: bool,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         params = {
             "offset": offset,
             "limit": limit,
             "excludeStopped": exclude_stopped,
         }
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.moderation_url}/internal/watchlist/authors",
-                params=params,
-                headers=self.headers,
-            )
-            resp.raise_for_status()
-            data = resp.json()
+        data = await self._moderation_request(
+            "GET",
+            "/internal/watchlist/authors",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            params=params,
+        )
 
-        items = await self._enrich_authors(data["items"])
+        items = await self._enrich_authors(
+            data["items"],
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return {
             "items": items,
             "total": data["total"],
             "hasMore": data["hasMore"],
         }
 
-    async def get_author_details(self, id: int, offset: int, limit: int) -> dict:
+    async def get_author_details(
+        self,
+        id: int,
+        offset: int,
+        limit: int,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         params = {"offset": offset, "limit": limit}
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.moderation_url}/internal/watchlist/authors/{id}",
-                params=params,
-                headers=self.headers,
-            )
-            if resp.status_code == 404:
-                raise HTTPException(status_code=404, detail="Watchlist author not found")
-            resp.raise_for_status()
-            data = resp.json()
+        data = await self._moderation_request(
+            "GET",
+            f"/internal/watchlist/authors/{id}",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            params=params,
+            status_details={404: "Watchlist author not found"},
+        )
 
-        enriched_list = await self._enrich_authors([data])
+        enriched_list = await self._enrich_authors(
+            [data],
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         enriched_author = enriched_list[0] if enriched_list else data
 
         return {
@@ -53,52 +94,82 @@ class WatchlistGatewayService:
             "comments": data["comments"],
         }
 
-    async def create_author(self, payload: dict) -> dict:
+    async def create_author(
+        self,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         backend_payload = {}
         if "authorVkId" in payload:
             backend_payload["author_vk_id"] = payload["authorVkId"]
         if "commentId" in payload:
             backend_payload["comment_id"] = payload["commentId"]
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self.moderation_url}/internal/watchlist/authors",
-                json=backend_payload,
-                headers=self.headers,
-            )
-            if resp.status_code == 404:
-                raise HTTPException(status_code=404, detail="Source comment not found")
-            if resp.status_code == 409:
-                raise HTTPException(status_code=409, detail="Author already in watchlist")
-            resp.raise_for_status()
-            data = resp.json()
+        data = await self._moderation_request(
+            "POST",
+            "/internal/watchlist/authors",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            json=backend_payload,
+            status_details={
+                404: "Source comment not found",
+                409: "Author already in watchlist",
+            },
+        )
 
-        enriched = await self._enrich_authors([data])
+        enriched = await self._enrich_authors(
+            [data],
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return enriched[0] if enriched else data
 
-    async def update_author(self, id: int, payload: dict) -> dict:
-        async with httpx.AsyncClient() as client:
-            resp = await client.patch(
-                f"{self.moderation_url}/internal/watchlist/authors/{id}",
-                json=payload,
-                headers=self.headers,
-            )
-            if resp.status_code == 404:
-                raise HTTPException(status_code=404, detail="Watchlist author not found")
-            resp.raise_for_status()
-            data = resp.json()
+    async def update_author(
+        self,
+        id: int,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        data = await self._moderation_request(
+            "PATCH",
+            f"/internal/watchlist/authors/{id}",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            json=payload,
+            status_details={404: "Watchlist author not found"},
+        )
 
-        enriched = await self._enrich_authors([data])
+        enriched = await self._enrich_authors(
+            [data],
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
         return enriched[0] if enriched else data
 
-    async def get_settings(self) -> dict:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.moderation_url}/internal/watchlist/settings",
-                headers=self.headers,
-            )
-            resp.raise_for_status()
-            data = resp.json()
+    async def get_settings(
+        self,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        data = await self._moderation_request(
+            "GET",
+            "/internal/watchlist/settings",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
 
         # Map settings to camelCase
         return {
@@ -108,7 +179,14 @@ class WatchlistGatewayService:
             "maxAuthors": data["max_authors"],
         }
 
-    async def update_settings(self, payload: dict) -> dict:
+    async def update_settings(
+        self,
+        payload: dict,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
         # Adapt frontend camelCase to backend snake_case
         backend_payload = {}
         if "trackAllComments" in payload:
@@ -118,14 +196,14 @@ class WatchlistGatewayService:
         if "maxAuthors" in payload:
             backend_payload["max_authors"] = payload["maxAuthors"]
 
-        async with httpx.AsyncClient() as client:
-            resp = await client.patch(
-                f"{self.moderation_url}/internal/watchlist/settings",
-                json=backend_payload,
-                headers=self.headers,
-            )
-            resp.raise_for_status()
-            data = resp.json()
+        data = await self._moderation_request(
+            "PATCH",
+            "/internal/watchlist/settings",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            json=backend_payload,
+        )
 
         return {
             "id": data["id"],
@@ -134,20 +212,64 @@ class WatchlistGatewayService:
             "maxAuthors": data["max_authors"],
         }
 
-    async def manual_refresh(self) -> dict:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self.moderation_url}/internal/watchlist/refresh",
-                headers=self.headers,
-            )
-            resp.raise_for_status()
-            return resp.json()
+    async def manual_refresh(
+        self,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict:
+        return await self._moderation_request(
+            "POST",
+            "/internal/watchlist/refresh",
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )
 
     # ------------------------------------------------------------------ #
     #  Private helpers                                                     #
     # ------------------------------------------------------------------ #
 
-    async def _enrich_authors(self, records: list[dict]) -> list[dict]:
+    async def _moderation_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+        params: dict | None = None,
+        json: Any | None = None,
+        status_details: dict[int, str] | None = None,
+    ) -> dict:
+        try:
+            return await self.moderation_client.request(
+                method,
+                path,
+                user_id=user_id,
+                request_id=request_id,
+                correlation_id=correlation_id,
+                params=params,
+                json=json,
+            )
+        except ModerationClientHTTPError as exc:
+            detail = (status_details or {}).get(exc.status_code, exc.detail)
+            raise HTTPException(status_code=exc.status_code, detail=detail) from exc
+        except ModerationClientUnavailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Moderation service unavailable",
+            ) from exc
+
+    async def _enrich_authors(
+        self,
+        records: list[dict],
+        *,
+        user_id: str | None = None,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> list[dict]:
         if not records:
             return []
 
@@ -156,15 +278,16 @@ class WatchlistGatewayService:
 
         if author_vk_ids:
             try:
-                async with httpx.AsyncClient() as client:
-                    resp = await client.post(
-                        f"{self.content_url}/internal/content/authors/bulk",
-                        json=author_vk_ids,
-                        headers=self.headers,
-                    )
-                    if resp.status_code == 200:
-                        authors_dict = {a["vkAuthorId"]: a for a in resp.json() if "vkAuthorId" in a}
-            except Exception:
+                authors = await self.content_client.request(
+                    "POST",
+                    "/internal/content/authors/bulk",
+                    user_id=user_id,
+                    request_id=request_id,
+                    correlation_id=correlation_id,
+                    json=author_vk_ids,
+                )
+                authors_dict = {a["vkAuthorId"]: a for a in authors if "vkAuthorId" in a}
+            except (ContentClientHTTPError, ContentClientUnavailableError):
                 # Fallback if content-service is down
                 pass
 

--- a/services/api-gateway/tests/test_comments_router.py
+++ b/services/api-gateway/tests/test_comments_router.py
@@ -1,3 +1,4 @@
+﻿# ruff: noqa: E402
 import sys
 from pathlib import Path
 
@@ -15,7 +16,6 @@ import app.core.security as _security
 from app.main import create_app
 from app.modules.comments.service import get_comments_gateway_service
 from test_jwt_validation import make_token
-
 
 # ------------------------------------------------------------------ #
 #  Fake service                                                       #
@@ -58,11 +58,11 @@ class FakeCommentsGatewayService:
             "unreadCount": 1,
         }
 
-    async def patch_read_status(self, id: int, payload: dict):
+    async def patch_read_status(self, id: int, payload: dict, **kwargs):
         is_read = payload.get("isRead", payload.get("is_read", True))
         return {**COMMENT_STUB, "id": id, "isRead": is_read}
 
-    async def search_comments(self, payload: dict):
+    async def search_comments(self, payload: dict, **kwargs):
         return {
             "source": "fallback",
             "viewMode": payload.get("viewMode", "comments"),

--- a/services/api-gateway/tests/test_comments_service.py
+++ b/services/api-gateway/tests/test_comments_service.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.modules.pop("_service_path", None)
@@ -10,16 +11,19 @@ from _service_path import use_service_path  # noqa: E402
 
 use_service_path()
 
+from app.clients.moderation.client import (  # noqa: E402
+    ModerationClientHTTPError,
+    ModerationClientUnavailableError,
+)
 from app.modules.comments.service import CommentsGatewayService  # noqa: E402
 
 
-class _Response:
-    status_code = 200
+class RecordingModerationClient:
+    def __init__(self):
+        self.calls: list[dict] = []
 
-    def raise_for_status(self):
-        return None
-
-    def json(self):
+    async def request(self, method: str, path: str, **kwargs):
+        self.calls.append({"method": method, "path": path, **kwargs})
         return {
             "id": 42,
             "external_key": "1:2:42",
@@ -32,29 +36,87 @@ class _Response:
         }
 
 
-class RecordingAsyncClient:
-    last_patch_json = None
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb):
-        return False
-
-    async def patch(self, *args, **kwargs):
-        RecordingAsyncClient.last_patch_json = kwargs.get("json")
-        return _Response()
+class EmptyContentClient:
+    async def request(self, method: str, path: str, **kwargs):
+        return []
 
 
 @pytest.mark.asyncio
-async def test_patch_read_status_rejects_non_boolean_payload(monkeypatch):
-    import app.modules.comments.service as comments_service
+async def test_patch_read_status_rejects_non_boolean_payload():
+    moderation_client = RecordingModerationClient()
+    service = CommentsGatewayService(
+        moderation_client=moderation_client,
+        content_client=EmptyContentClient(),
+    )
 
-    monkeypatch.setattr(comments_service.httpx, "AsyncClient", RecordingAsyncClient)
-    service = CommentsGatewayService()
-
-    with pytest.raises(comments_service.HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         await service.patch_read_status(42, {"isRead": "false"})
 
     assert exc_info.value.status_code == 422
-    assert RecordingAsyncClient.last_patch_json is None
+    assert moderation_client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_patch_read_status_uses_typed_client_payload_and_context():
+    moderation_client = RecordingModerationClient()
+    service = CommentsGatewayService(
+        moderation_client=moderation_client,
+        content_client=EmptyContentClient(),
+    )
+
+    result = await service.patch_read_status(
+        42,
+        {"isRead": True},
+        user_id="user-1",
+        request_id="req-1",
+        correlation_id="corr-1",
+    )
+
+    assert result["isRead"] is False
+    assert moderation_client.calls == [
+        {
+            "method": "PATCH",
+            "path": "/internal/moderation/comments/42/read",
+            "user_id": "user-1",
+            "request_id": "req-1",
+            "correlation_id": "corr-1",
+            "params": None,
+            "json": {"is_read": True},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_comments_preserves_upstream_http_status():
+    class FailingModerationClient:
+        async def request(self, method: str, path: str, **kwargs):
+            raise ModerationClientHTTPError(status_code=409, detail={"detail": "conflict"})
+
+    service = CommentsGatewayService(
+        moderation_client=FailingModerationClient(),
+        content_client=EmptyContentClient(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_comments(page=1, limit=20)
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == {"detail": "conflict"}
+
+
+@pytest.mark.asyncio
+async def test_get_comments_maps_unavailable_upstream_to_503():
+    class UnavailableModerationClient:
+        async def request(self, method: str, path: str, **kwargs):
+            raise ModerationClientUnavailableError("Moderation service is unavailable")
+
+    service = CommentsGatewayService(
+        moderation_client=UnavailableModerationClient(),
+        content_client=EmptyContentClient(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_comments(page=1, limit=20)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Moderation service unavailable"

--- a/services/api-gateway/tests/test_keywords_gateway.py
+++ b/services/api-gateway/tests/test_keywords_gateway.py
@@ -1,13 +1,32 @@
+﻿# ruff: noqa: E402
 import sys
 from pathlib import Path
+
 import pytest
 from fastapi import HTTPException
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _service_path import use_service_path
+
 use_service_path()
 
+from app.clients.moderation.client import (
+    ModerationClientHTTPError,
+    ModerationClientUnavailableError,
+)
 from app.modules.keywords.service import KeywordsGatewayService
+
+
+class RecordingModerationClient:
+    base_url = "http://moderation"
+
+    def __init__(self, response: dict):
+        self.response = response
+        self.calls: list[dict] = []
+
+    async def request(self, method: str, path: str, **kwargs):
+        self.calls.append({"method": method, "path": path, **kwargs})
+        return self.response
 
 
 def test_format_keyword():
@@ -98,3 +117,74 @@ async def test_upload_keywords_validations():
         await service.upload_keywords(invalid_encoding_file)
     assert exc_info.value.status_code == 400
     assert "encoding must be UTF-8" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_add_keyword_uses_typed_client_payload_and_context():
+    moderation_client = RecordingModerationClient(
+        {
+            "id": 1,
+            "word": "cat",
+            "category": "animals",
+            "is_phrase": False,
+            "created_at": "2026-05-24T12:00:00Z",
+            "updated_at": "2026-05-24T12:00:00Z",
+        }
+    )
+    service = KeywordsGatewayService(moderation_client=moderation_client)
+
+    result = await service.add_keyword(
+        {"word": "cat", "category": "animals", "isPhrase": False},
+        user_id="user-1",
+        request_id="req-1",
+        correlation_id="corr-1",
+    )
+
+    assert result["word"] == "cat"
+    assert moderation_client.calls == [{
+        "method": "POST",
+        "path": "/internal/moderation/keywords/add",
+        "user_id": "user-1",
+        "request_id": "req-1",
+        "correlation_id": "corr-1",
+        "params": None,
+        "json": {
+            "word": "cat",
+            "category": "animals",
+            "is_phrase": False,
+        },
+    }]
+
+
+@pytest.mark.asyncio
+async def test_keywords_preserves_upstream_http_status_detail():
+    class FailingModerationClient:
+        base_url = "http://moderation"
+
+        async def request(self, method: str, path: str, **kwargs):
+            raise ModerationClientHTTPError(status_code=404, detail={"detail": "missing"})
+
+    service = KeywordsGatewayService(moderation_client=FailingModerationClient())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.delete_keyword(99)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "missing"
+
+
+@pytest.mark.asyncio
+async def test_keywords_maps_unavailable_upstream_to_503():
+    class UnavailableModerationClient:
+        base_url = "http://moderation"
+
+        async def request(self, method: str, path: str, **kwargs):
+            raise ModerationClientUnavailableError("Moderation service is unavailable")
+
+    service = KeywordsGatewayService(moderation_client=UnavailableModerationClient())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_all_keywords(page=1, limit=50)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Moderation service unavailable"

--- a/services/api-gateway/tests/test_watchlist_gateway.py
+++ b/services/api-gateway/tests/test_watchlist_gateway.py
@@ -1,30 +1,56 @@
+﻿# ruff: noqa: E402
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
+
 import pytest
+from fastapi import HTTPException
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _service_path import use_service_path
+
 use_service_path()
 
+from app.clients.moderation.client import (
+    ModerationClientHTTPError,
+    ModerationClientUnavailableError,
+)
 from app.modules.watchlist.service import WatchlistGatewayService
 
 
-@pytest.mark.asyncio
-@patch("httpx.AsyncClient.post")
-async def test_gateway_create_author_payload_translation(mock_post):
-    service = WatchlistGatewayService()
+class RecordingModerationClient:
+    base_url = "http://moderation"
 
-    # Mock response from moderation-service
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.json.return_value = {
+    def __init__(self, response: dict):
+        self.response = response
+        self.calls: list[dict] = []
+
+    async def request(self, method: str, path: str, **kwargs):
+        self.calls.append({"method": method, "path": path, **kwargs})
+        return self.response
+
+
+class EmptyContentClient:
+    base_url = "http://content"
+
+    async def request(self, method: str, path: str, **kwargs):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_gateway_create_author_payload_translation():
+    moderation_client = RecordingModerationClient(
+        {
         "id": 1,
         "author_vk_id": 123,
         "status": "ACTIVE",
         "monitoring_started_at": "2026-05-24T12:00:00Z",
-    }
-    mock_post.return_value = mock_resp
+        }
+    )
+    service = WatchlistGatewayService(
+        moderation_client=moderation_client,
+        content_client=EmptyContentClient(),
+    )
 
     # Input payload from frontend (camelCase)
     frontend_payload = {
@@ -43,34 +69,42 @@ async def test_gateway_create_author_payload_translation(mock_post):
             "summary": None,
         }]
 
-        result = await service.create_author(frontend_payload)
+        result = await service.create_author(
+            frontend_payload,
+            user_id="user-1",
+            request_id="req-1",
+            correlation_id="corr-1",
+        )
 
-    # Check that HTTP POST request was made with snake_case payload
-    mock_post.assert_called_once()
-    args, kwargs = mock_post.call_args
-    assert args[0] == f"{service.moderation_url}/internal/watchlist/authors"
-    assert kwargs["json"] == {
+    assert moderation_client.calls == [{
+        "method": "POST",
+        "path": "/internal/watchlist/authors",
+        "user_id": "user-1",
+        "request_id": "req-1",
+        "correlation_id": "corr-1",
+        "params": None,
+        "json": {
         "author_vk_id": 123,
         "comment_id": 456,
-    }
+        },
+    }]
     assert result["authorVkId"] == 123
 
 
 @pytest.mark.asyncio
-@patch("httpx.AsyncClient.patch")
-async def test_gateway_update_settings_payload_translation(mock_patch):
-    service = WatchlistGatewayService()
-
-    # Mock response from moderation-service
-    mock_resp = MagicMock()
-    mock_resp.status_code = 200
-    mock_resp.json.return_value = {
+async def test_gateway_update_settings_payload_translation():
+    moderation_client = RecordingModerationClient(
+        {
         "id": 1,
         "track_all_comments": True,
         "poll_interval_minutes": 10,
         "max_authors": 30,
-    }
-    mock_patch.return_value = mock_resp
+        }
+    )
+    service = WatchlistGatewayService(
+        moderation_client=moderation_client,
+        content_client=EmptyContentClient(),
+    )
 
     frontend_payload = {
         "trackAllComments": True,
@@ -78,17 +112,66 @@ async def test_gateway_update_settings_payload_translation(mock_patch):
         "maxAuthors": 30,
     }
 
-    result = await service.update_settings(frontend_payload)
+    result = await service.update_settings(
+        frontend_payload,
+        user_id="user-1",
+        request_id="req-1",
+        correlation_id="corr-1",
+    )
 
-    # Check that HTTP PATCH request was made with snake_case payload
-    mock_patch.assert_called_once()
-    args, kwargs = mock_patch.call_args
-    assert args[0] == f"{service.moderation_url}/internal/watchlist/settings"
-    assert kwargs["json"] == {
+    assert moderation_client.calls == [{
+        "method": "PATCH",
+        "path": "/internal/watchlist/settings",
+        "user_id": "user-1",
+        "request_id": "req-1",
+        "correlation_id": "corr-1",
+        "params": None,
+        "json": {
         "track_all_comments": True,
         "poll_interval_minutes": 10,
         "max_authors": 30,
-    }
+        },
+    }]
     assert result["trackAllComments"] is True
     assert result["pollIntervalMinutes"] == 10
     assert result["maxAuthors"] == 30
+
+
+@pytest.mark.asyncio
+async def test_gateway_create_author_preserves_conflict_status():
+    class ConflictModerationClient:
+        base_url = "http://moderation"
+
+        async def request(self, method: str, path: str, **kwargs):
+            raise ModerationClientHTTPError(status_code=409, detail={"detail": "duplicate"})
+
+    service = WatchlistGatewayService(
+        moderation_client=ConflictModerationClient(),
+        content_client=EmptyContentClient(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.create_author({"authorVkId": 123})
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "Author already in watchlist"
+
+
+@pytest.mark.asyncio
+async def test_gateway_watchlist_maps_unavailable_upstream_to_503():
+    class UnavailableModerationClient:
+        base_url = "http://moderation"
+
+        async def request(self, method: str, path: str, **kwargs):
+            raise ModerationClientUnavailableError("Moderation service is unavailable")
+
+    service = WatchlistGatewayService(
+        moderation_client=UnavailableModerationClient(),
+        content_client=EmptyContentClient(),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.get_authors(offset=0, limit=20, exclude_stopped=True)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Moderation service unavailable"


### PR DESCRIPTION
Closes #243

## Summary
- Route comments gateway moderation/content forwarding through `ModerationClient` and `ContentClient`.
- Route watchlist gateway moderation/content forwarding through typed clients while preserving 404/409 response details and enrichment fallback behavior.
- Route keywords gateway forwarding through `ModerationClient` and propagate user/request/correlation context from routers.
- Add targeted tests for payload translation, typed-client context propagation, upstream HTTP passthrough, unavailable upstream mapping, and response-shape compatibility.

## Validation
- [x] `uv run --extra test python -m pytest tests/test_comments_service.py tests/test_comments_router.py tests/test_watchlist_gateway.py tests/test_keywords_gateway.py` — 23 passed
- [x] `uv run --extra test python -m pytest tests/test_comments_service.py tests/test_comments_router.py tests/test_watchlist_gateway.py tests/test_keywords_gateway.py tests/test_internal_client.py tests/test_content_gateway.py tests/test_tasks_gateway.py tests/test_auth_gateway.py tests/test_jwt_validation.py tests/test_redaction_gateway.py tests/test_photo_analysis_gateway.py` — 52 passed
- [x] `uv run --with ruff ruff check app/modules/comments/service.py app/modules/comments/router.py app/modules/watchlist/service.py app/modules/watchlist/router.py app/modules/keywords/service.py app/modules/keywords/router.py tests/test_comments_service.py tests/test_comments_router.py tests/test_watchlist_gateway.py tests/test_keywords_gateway.py` — passed
- [x] `python .agents\skills\parsevk-service-architecture\scripts\validate-service.py --no-db services\api-gateway` — 28 passed
- [ ] `uv run --extra test python -m pytest` — 97 passed, 1 existing failure in `test_telegram_tgmbase_capabilities_describe_gateway_boundary` outside this scope
- [ ] `uv run --with ruff ruff check .` — fails on existing repo-wide lint debt outside changed files

## Notes
- Frontend-facing response shapes are preserved.
- Target modules no longer instantiate `httpx.AsyncClient` directly for normal JSON forwarding.
- No frontend, moderation-service, or content-service contract changes are included.