### PR TITLE
refactor(api-gateway): consolidate friends export adapters

### DIFF
--- a/services/api-gateway/app/modules/friends_export/provider_adapter.py
+++ b/services/api-gateway/app/modules/friends_export/provider_adapter.py
@@ -1,0 +1,214 @@
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+from app.clients.vk_service.client import (
+    VkServiceClient,
+    VkServiceClientHTTPError,
+    VkServiceClientUnavailableError,
+)
+from app.core.redaction import redact_secrets
+from app.modules.friends_export.models import (
+    DoneEventData,
+    ErrorEventData,
+    FriendsExportStartResponse,
+    FriendsJobDetailResponse,
+    FriendsJobLogEntry,
+    FriendsJobState,
+    JobStatus,
+    LogEventData,
+    ProgressEventData,
+    SseDoneEvent,
+    SseErrorEvent,
+    SseEvent,
+    SseLogEvent,
+    SseProgressEvent,
+)
+from fastapi import HTTPException
+
+
+class ProviderFriendsAdapter:
+    """Shared vk-service backed adapter for provider-specific friends export paths."""
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        unavailable_detail: str,
+        client: VkServiceClient,
+        user_id: str,
+        request_id: str | None = None,
+        correlation_id: str | None = None,
+    ) -> None:
+        self.provider = provider
+        self.unavailable_detail = unavailable_detail
+        self.client = client
+        self.user_id = user_id
+        self.request_id = request_id
+        self.correlation_id = correlation_id
+
+    @property
+    def _base_path(self) -> str:
+        return f"/internal/{self.provider}/friends"
+
+    async def start_export(self, params: dict[str, Any]) -> FriendsExportStartResponse:
+        try:
+            res = await self.client.request(
+                "POST",
+                f"{self._base_path}/export",
+                user_id=self.user_id,
+                request_id=self.request_id,
+                correlation_id=self.correlation_id,
+                json={"params": params},
+            )
+            return FriendsExportStartResponse(
+                jobId=res["jobId"],
+                status=JobStatus(res["status"]),
+            )
+        except VkServiceClientHTTPError as exc:
+            raise HTTPException(
+                status_code=exc.status_code,
+                detail=redact_secrets(exc.detail),
+            ) from exc
+        except VkServiceClientUnavailableError as exc:
+            raise HTTPException(status_code=502, detail=self.unavailable_detail) from exc
+
+    async def get_job(self, job_id: str) -> FriendsJobDetailResponse:
+        try:
+            res = await self.client.request(
+                "GET",
+                f"{self._base_path}/jobs/{job_id}",
+                user_id=self.user_id,
+                request_id=self.request_id,
+                correlation_id=self.correlation_id,
+            )
+            return FriendsJobDetailResponse(
+                job=self._job_state(res["job"]),
+                logs=[self._log_entry(log) for log in res["logs"]],
+            )
+        except VkServiceClientHTTPError as exc:
+            raise HTTPException(
+                status_code=exc.status_code,
+                detail=redact_secrets(exc.detail),
+            ) from exc
+        except VkServiceClientUnavailableError as exc:
+            raise HTTPException(status_code=502, detail=self.unavailable_detail) from exc
+
+    async def stream_job(self, job_id: str) -> AsyncIterator[SseEvent]:
+        emitted_logs_count = 0
+        last_progress_count = -1
+        max_polls = 600
+        poll_count = 0
+
+        while poll_count < max_polls:
+            try:
+                res = await self.client.request(
+                    "GET",
+                    f"{self._base_path}/jobs/{job_id}/logs/raw",
+                    user_id=self.user_id,
+                    request_id=self.request_id,
+                    correlation_id=self.correlation_id,
+                )
+            except Exception as exc:
+                yield SseErrorEvent(
+                    data=ErrorEventData(
+                        message=redact_secrets(f"Upstream connection lost: {exc}")
+                    )
+                )
+                return
+
+            job = res["job"]
+            logs = res["logs"]
+            status = job["status"]
+
+            if len(logs) > emitted_logs_count:
+                for log in logs[emitted_logs_count:]:
+                    yield SseLogEvent(
+                        data=LogEventData(
+                            level=log["level"],
+                            message=redact_secrets(log["message"]),
+                            meta=log["meta"],
+                        )
+                    )
+                emitted_logs_count = len(logs)
+
+            fetched = job["fetchedCount"]
+            total = job["totalCount"]
+            limit_applied = fetched == 5000 and job.get("warning") is not None
+
+            if fetched != last_progress_count:
+                yield SseProgressEvent(
+                    data=ProgressEventData(
+                        fetchedCount=fetched,
+                        totalCount=total,
+                        limitApplied=limit_applied,
+                    )
+                )
+                last_progress_count = fetched
+
+            if status == JobStatus.DONE.value:
+                yield SseDoneEvent(
+                    data=DoneEventData(
+                        jobId=job["id"],
+                        fetchedCount=fetched,
+                        totalCount=total,
+                        warning=(
+                            redact_secrets(job["warning"]) if job.get("warning") else None
+                        ),
+                        xlsxPath=job["xlsxPath"],
+                    )
+                )
+                return
+
+            if status == JobStatus.FAILED.value:
+                yield SseErrorEvent(
+                    data=ErrorEventData(
+                        message=redact_secrets(job.get("error") or "Export failed")
+                    )
+                )
+                return
+
+            await asyncio.sleep(1.0)
+            poll_count += 1
+
+        yield SseErrorEvent(data=ErrorEventData(message="Export timeout exceeded"))
+
+    async def get_xlsx_bytes(self, job_id: str) -> bytes:
+        try:
+            return await self.client.get_xlsx_bytes(
+                job_id,
+                provider=self.provider,
+                user_id=self.user_id,
+                request_id=self.request_id,
+                correlation_id=self.correlation_id,
+            )
+        except VkServiceClientHTTPError as exc:
+            raise HTTPException(
+                status_code=exc.status_code,
+                detail=redact_secrets(exc.detail),
+            ) from exc
+        except VkServiceClientUnavailableError as exc:
+            raise HTTPException(status_code=502, detail=self.unavailable_detail) from exc
+
+    @staticmethod
+    def _job_state(job: dict[str, Any]) -> FriendsJobState:
+        return FriendsJobState(
+            id=job["id"],
+            status=JobStatus(job["status"]),
+            fetchedCount=job["fetchedCount"],
+            totalCount=job["totalCount"],
+            warning=redact_secrets(job["warning"]) if job.get("warning") else None,
+            error=redact_secrets(job["error"]) if job.get("error") else None,
+            xlsxPath=job["xlsxPath"],
+            createdAt=job["createdAt"],
+        )
+
+    @staticmethod
+    def _log_entry(log: dict[str, Any]) -> FriendsJobLogEntry:
+        return FriendsJobLogEntry(
+            id=log["id"],
+            level=log["level"],
+            message=redact_secrets(log["message"]),
+            meta=log["meta"],
+            createdAt=log["createdAt"],
+        )

--- a/services/api-gateway/app/modules/ok_friends/adapters.py
+++ b/services/api-gateway/app/modules/ok_friends/adapters.py
@@ -1,35 +1,12 @@
-import asyncio
-from typing import Any, AsyncIterator
-
-from app.clients.vk_service.client import (
-    VkServiceClient,
-    VkServiceClientHTTPError,
-    VkServiceClientUnavailableError,
-)
-from fastapi import HTTPException
-from app.core.redaction import redact_secrets
-from app.modules.friends_export.models import (
-    DoneEventData,
-    ErrorEventData,
-    FriendsExportStartResponse,
-    FriendsJobDetailResponse,
-    FriendsJobLogEntry,
-    FriendsJobState,
-    JobStatus,
-    LogEventData,
-    ProgressEventData,
-    SseDoneEvent,
-    SseErrorEvent,
-    SseLogEvent,
-    SseProgressEvent,
-    SseEvent,
-)
+from app.clients.vk_service.client import VkServiceClient
+from app.modules.friends_export.provider_adapter import ProviderFriendsAdapter
 
 
-class OkFriendsAdapter:
+class OkFriendsAdapter(ProviderFriendsAdapter):
     """
-    OK specific adapter for friends export.
-    Acts as an HTTP proxy/translator to downstream social service (vk-service).
+    OK compatibility wrapper for the shared friends export adapter.
+
+    Import path and class name are kept stable for routers and tests.
     """
 
     def __init__(
@@ -39,157 +16,11 @@ class OkFriendsAdapter:
         request_id: str | None = None,
         correlation_id: str | None = None,
     ) -> None:
-        self.client = client
-        self.user_id = user_id
-        self.request_id = request_id
-        self.correlation_id = correlation_id
-
-    async def start_export(self, params: dict[str, Any]) -> FriendsExportStartResponse:
-        try:
-            res = await self.client.request(
-                "POST",
-                "/internal/ok/friends/export",
-                user_id=self.user_id,
-                request_id=self.request_id,
-                correlation_id=self.correlation_id,
-                json={"params": params},
-            )
-            return FriendsExportStartResponse(
-                jobId=res["jobId"], status=JobStatus(res["status"])
-            )
-        except VkServiceClientHTTPError as exc:
-            raise HTTPException(status_code=exc.status_code, detail=redact_secrets(exc.detail)) from exc
-        except VkServiceClientUnavailableError as exc:
-            raise HTTPException(status_code=502, detail="Social service is unavailable") from exc
-
-    async def get_job(self, job_id: str) -> FriendsJobDetailResponse:
-        try:
-            res = await self.client.request(
-                "GET",
-                f"/internal/ok/friends/jobs/{job_id}",
-                user_id=self.user_id,
-                request_id=self.request_id,
-                correlation_id=self.correlation_id,
-            )
-            job = res["job"]
-            logs = res["logs"]
-
-            job_state = FriendsJobState(
-                id=job["id"],
-                status=JobStatus(job["status"]),
-                fetchedCount=job["fetchedCount"],
-                totalCount=job["totalCount"],
-                warning=redact_secrets(job["warning"]) if job.get("warning") else None,
-                error=redact_secrets(job["error"]) if job.get("error") else None,
-                xlsxPath=job["xlsxPath"],
-                createdAt=job["createdAt"],
-            )
-
-            log_entries = [
-                FriendsJobLogEntry(
-                    id=log["id"],
-                    level=log["level"],
-                    message=redact_secrets(log["message"]),
-                    meta=log["meta"],
-                    createdAt=log["createdAt"],
-                )
-                for log in logs
-            ]
-
-            return FriendsJobDetailResponse(job=job_state, logs=log_entries)
-        except VkServiceClientHTTPError as exc:
-            raise HTTPException(status_code=exc.status_code, detail=redact_secrets(exc.detail)) from exc
-        except VkServiceClientUnavailableError as exc:
-            raise HTTPException(status_code=502, detail="Social service is unavailable") from exc
-
-    async def stream_job(self, job_id: str) -> AsyncIterator[SseEvent]:
-        emitted_logs_count = 0
-        last_progress_count = -1
-        max_polls = 600  # 10 minutes timeout
-        poll_count = 0
-
-        while poll_count < max_polls:
-            try:
-                res = await self.client.request(
-                    "GET",
-                    f"/internal/ok/friends/jobs/{job_id}/logs/raw",
-                    user_id=self.user_id,
-                    request_id=self.request_id,
-                    correlation_id=self.correlation_id,
-                )
-            except Exception as exc:
-                yield SseErrorEvent(
-                    data=ErrorEventData(message=redact_secrets(f"Upstream connection lost: {exc}"))
-                )
-                return
-
-            job = res["job"]
-            logs = res["logs"]
-            status = job["status"]
-
-            # 1. Emit new logs
-            if len(logs) > emitted_logs_count:
-                new_logs = logs[emitted_logs_count:]
-                for log in new_logs:
-                    yield SseLogEvent(
-                        data=LogEventData(
-                            level=log["level"],
-                            message=redact_secrets(log["message"]),
-                            meta=log["meta"],
-                        )
-                    )
-                emitted_logs_count = len(logs)
-
-            # 2. Emit progress updates if progress changed
-            fetched = job["fetchedCount"]
-            total = job["totalCount"]
-            limit_applied = fetched == 5000 and job.get("warning") is not None
-            
-            if fetched != last_progress_count:
-                yield SseProgressEvent(
-                    data=ProgressEventData(
-                        fetchedCount=fetched,
-                        totalCount=total,
-                        limitApplied=limit_applied,
-                    )
-                )
-                last_progress_count = fetched
-
-            # 3. Check termination status
-            if status == JobStatus.DONE.value:
-                yield SseDoneEvent(
-                    data=DoneEventData(
-                        jobId=job["id"],
-                        fetchedCount=fetched,
-                        totalCount=total,
-                        warning=redact_secrets(job["warning"]) if job.get("warning") else None,
-                        xlsxPath=job["xlsxPath"],
-                    )
-                )
-                return
-
-            if status == JobStatus.FAILED.value:
-                yield SseErrorEvent(
-                    data=ErrorEventData(message=redact_secrets(job.get("error") or "Export failed"))
-                )
-                return
-
-            await asyncio.sleep(1.0)
-            poll_count += 1
-
-        # Timeout hit
-        yield SseErrorEvent(data=ErrorEventData(message="Export timeout exceeded"))
-
-    async def get_xlsx_bytes(self, job_id: str) -> bytes:
-        try:
-            return await self.client.get_xlsx_bytes(
-                job_id,
-                provider="ok",
-                user_id=self.user_id,
-                request_id=self.request_id,
-                correlation_id=self.correlation_id,
-            )
-        except VkServiceClientHTTPError as exc:
-            raise HTTPException(status_code=exc.status_code, detail=redact_secrets(exc.detail)) from exc
-        except VkServiceClientUnavailableError as exc:
-            raise HTTPException(status_code=502, detail="Social service is unavailable") from exc
+        super().__init__(
+            provider="ok",
+            unavailable_detail="Social service is unavailable",
+            client=client,
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )

--- a/services/api-gateway/app/modules/vk_friends/adapters.py
+++ b/services/api-gateway/app/modules/vk_friends/adapters.py
@@ -1,35 +1,12 @@
-import asyncio
-from typing import Any, AsyncIterator
-
-from app.clients.vk_service.client import (
-    VkServiceClient,
-    VkServiceClientHTTPError,
-    VkServiceClientUnavailableError,
-)
-from fastapi import HTTPException
-from app.core.redaction import redact_secrets
-from app.modules.friends_export.models import (
-    DoneEventData,
-    ErrorEventData,
-    FriendsExportStartResponse,
-    FriendsJobDetailResponse,
-    FriendsJobLogEntry,
-    FriendsJobState,
-    JobStatus,
-    LogEventData,
-    ProgressEventData,
-    SseDoneEvent,
-    SseErrorEvent,
-    SseLogEvent,
-    SseProgressEvent,
-    SseEvent,
-)
+from app.clients.vk_service.client import VkServiceClient
+from app.modules.friends_export.provider_adapter import ProviderFriendsAdapter
 
 
-class VkFriendsAdapter:
+class VkFriendsAdapter(ProviderFriendsAdapter):
     """
-    VK specific adapter for friends export.
-    Acts as an HTTP proxy/translator to downstream vk-service.
+    VK compatibility wrapper for the shared friends export adapter.
+
+    Import path and class name are kept stable for routers and tests.
     """
 
     def __init__(
@@ -39,157 +16,11 @@ class VkFriendsAdapter:
         request_id: str | None = None,
         correlation_id: str | None = None,
     ) -> None:
-        self.client = client
-        self.user_id = user_id
-        self.request_id = request_id
-        self.correlation_id = correlation_id
-
-    async def start_export(self, params: dict[str, Any]) -> FriendsExportStartResponse:
-        try:
-            res = await self.client.request(
-                "POST",
-                "/internal/vk/friends/export",
-                user_id=self.user_id,
-                request_id=self.request_id,
-                correlation_id=self.correlation_id,
-                json={"params": params},
-            )
-            return FriendsExportStartResponse(
-                jobId=res["jobId"], status=JobStatus(res["status"])
-            )
-        except VkServiceClientHTTPError as exc:
-            raise HTTPException(status_code=exc.status_code, detail=redact_secrets(exc.detail)) from exc
-        except VkServiceClientUnavailableError as exc:
-            raise HTTPException(status_code=502, detail="VK service is unavailable") from exc
-
-    async def get_job(self, job_id: str) -> FriendsJobDetailResponse:
-        try:
-            res = await self.client.request(
-                "GET",
-                f"/internal/vk/friends/jobs/{job_id}",
-                user_id=self.user_id,
-                request_id=self.request_id,
-                correlation_id=self.correlation_id,
-            )
-            job = res["job"]
-            logs = res["logs"]
-
-            job_state = FriendsJobState(
-                id=job["id"],
-                status=JobStatus(job["status"]),
-                fetchedCount=job["fetchedCount"],
-                totalCount=job["totalCount"],
-                warning=redact_secrets(job["warning"]) if job.get("warning") else None,
-                error=redact_secrets(job["error"]) if job.get("error") else None,
-                xlsxPath=job["xlsxPath"],
-                createdAt=job["createdAt"],
-            )
-
-            log_entries = [
-                FriendsJobLogEntry(
-                    id=log["id"],
-                    level=log["level"],
-                    message=redact_secrets(log["message"]),
-                    meta=log["meta"],
-                    createdAt=log["createdAt"],
-                )
-                for log in logs
-            ]
-
-            return FriendsJobDetailResponse(job=job_state, logs=log_entries)
-        except VkServiceClientHTTPError as exc:
-            raise HTTPException(status_code=exc.status_code, detail=redact_secrets(exc.detail)) from exc
-        except VkServiceClientUnavailableError as exc:
-            raise HTTPException(status_code=502, detail="VK service is unavailable") from exc
-
-    async def stream_job(self, job_id: str) -> AsyncIterator[SseEvent]:
-        # Track which logs have already been emitted to avoid duplication
-        emitted_logs_count = 0
-        last_progress_count = -1
-        max_polls = 600  # 10 minutes timeout
-        poll_count = 0
-
-        while poll_count < max_polls:
-            try:
-                res = await self.client.request(
-                    "GET",
-                    f"/internal/vk/friends/jobs/{job_id}/logs/raw",
-                    user_id=self.user_id,
-                    request_id=self.request_id,
-                    correlation_id=self.correlation_id,
-                )
-            except Exception as exc:
-                yield SseErrorEvent(
-                    data=ErrorEventData(message=redact_secrets(f"Upstream connection lost: {exc}"))
-                )
-                return
-
-            job = res["job"]
-            logs = res["logs"]
-            status = job["status"]
-
-            # 1. Emit new logs
-            if len(logs) > emitted_logs_count:
-                new_logs = logs[emitted_logs_count:]
-                for log in new_logs:
-                    yield SseLogEvent(
-                        data=LogEventData(
-                            level=log["level"],
-                            message=redact_secrets(log["message"]),
-                            meta=log["meta"],
-                        )
-                    )
-                emitted_logs_count = len(logs)
-
-            # 2. Emit progress updates if progress changed
-            fetched = job["fetchedCount"]
-            total = job["totalCount"]
-            limit_applied = fetched == 5000 and job.get("warning") is not None
-            
-            if fetched != last_progress_count:
-                yield SseProgressEvent(
-                    data=ProgressEventData(
-                        fetchedCount=fetched,
-                        totalCount=total,
-                        limitApplied=limit_applied,
-                    )
-                )
-                last_progress_count = fetched
-
-            # 3. Check termination status
-            if status == JobStatus.DONE.value:
-                yield SseDoneEvent(
-                    data=DoneEventData(
-                        jobId=job["id"],
-                        fetchedCount=fetched,
-                        totalCount=total,
-                        warning=redact_secrets(job["warning"]) if job.get("warning") else None,
-                        xlsxPath=job["xlsxPath"],
-                    )
-                )
-                return
-
-            if status == JobStatus.FAILED.value:
-                yield SseErrorEvent(
-                    data=ErrorEventData(message=redact_secrets(job.get("error") or "Export failed"))
-                )
-                return
-
-            await asyncio.sleep(1.0)
-            poll_count += 1
-
-        # Timeout hit
-        yield SseErrorEvent(data=ErrorEventData(message="Export timeout exceeded"))
-
-    async def get_xlsx_bytes(self, job_id: str) -> bytes:
-        try:
-            return await self.client.get_xlsx_bytes(
-                job_id,
-                user_id=self.user_id,
-                request_id=self.request_id,
-                correlation_id=self.correlation_id,
-            )
-        except VkServiceClientHTTPError as exc:
-            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
-        except VkServiceClientUnavailableError as exc:
-            raise HTTPException(status_code=502, detail="VK service is unavailable") from exc
+        super().__init__(
+            provider="vk",
+            unavailable_detail="VK service is unavailable",
+            client=client,
+            user_id=user_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+        )

--- a/services/api-gateway/tests/test_ok_friends_adapter.py
+++ b/services/api-gateway/tests/test_ok_friends_adapter.py
@@ -1,21 +1,21 @@
+﻿# ruff: noqa: E402, S108
 import sys
-import pytest
-import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 from httpx import ASGITransport, AsyncClient
-from fastapi import FastAPI, Depends
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _service_path import use_service_path
+
 use_service_path()
 
-from app.main import create_app
-from app.core.config import settings
-from app.core.security import require_auth
 from app.clients.vk_service.client import VkServiceClient
-from app.modules.ok_friends.adapters import OkFriendsAdapter
+from app.core.security import require_auth
+from app.main import create_app
 from app.modules.friends_export.models import JobStatus
+from app.modules.ok_friends.adapters import OkFriendsAdapter
 
 
 @pytest.fixture
@@ -144,6 +144,30 @@ async def test_adapter_stream_job():
 
     done_event = [e for e in events if e.type == "done"][0]
     assert done_event.data.xlsxPath == "/tmp/test_ok.xlsx"
+
+
+@pytest.mark.anyio
+async def test_adapter_get_xlsx_bytes_uses_ok_provider():
+    client_mock = AsyncMock()
+    client_mock.get_xlsx_bytes.return_value = b"xlsx"
+
+    adapter = OkFriendsAdapter(
+        client=client_mock,
+        user_id="user-777",
+        request_id="req-111",
+        correlation_id="corr-222",
+    )
+
+    result = await adapter.get_xlsx_bytes("job-123")
+
+    assert result == b"xlsx"
+    client_mock.get_xlsx_bytes.assert_called_once_with(
+        "job-123",
+        provider="ok",
+        user_id="user-777",
+        request_id="req-111",
+        correlation_id="corr-222",
+    )
 
 
 @pytest.mark.anyio

--- a/services/api-gateway/tests/test_vk_friends_adapter.py
+++ b/services/api-gateway/tests/test_vk_friends_adapter.py
@@ -1,21 +1,21 @@
+﻿# ruff: noqa: E402, S108
 import sys
-import pytest
-import asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 from httpx import ASGITransport, AsyncClient
-from fastapi import FastAPI, Depends
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _service_path import use_service_path
+
 use_service_path()
 
-from app.main import create_app
-from app.core.config import settings
-from app.core.security import require_auth
 from app.clients.vk_service.client import VkServiceClient
-from app.modules.vk_friends.adapters import VkFriendsAdapter
+from app.core.security import require_auth
+from app.main import create_app
 from app.modules.friends_export.models import JobStatus
+from app.modules.vk_friends.adapters import VkFriendsAdapter
 
 
 @pytest.fixture
@@ -147,6 +147,30 @@ async def test_adapter_stream_job():
 
     done_event = [e for e in events if e.type == "done"][0]
     assert done_event.data.xlsxPath == "/tmp/test.xlsx"
+
+
+@pytest.mark.anyio
+async def test_adapter_get_xlsx_bytes_uses_vk_provider():
+    client_mock = AsyncMock()
+    client_mock.get_xlsx_bytes.return_value = b"xlsx"
+
+    adapter = VkFriendsAdapter(
+        client=client_mock,
+        user_id="user-777",
+        request_id="req-111",
+        correlation_id="corr-222",
+    )
+
+    result = await adapter.get_xlsx_bytes("job-123")
+
+    assert result == b"xlsx"
+    client_mock.get_xlsx_bytes.assert_called_once_with(
+        "job-123",
+        provider="vk",
+        user_id="user-777",
+        request_id="req-111",
+        correlation_id="corr-222",
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #244

## Summary
- Add shared provider-aware `ProviderFriendsAdapter` for VK/OK friends export lifecycle.
- Keep `VkFriendsAdapter` and `OkFriendsAdapter` as compatibility wrappers over the shared adapter.
- Preserve provider-specific downstream paths, XLSX provider routing, unavailable-service messages, redaction, polling, timeout, and SSE event shapes.
- Add provider-specific XLSX routing tests for VK and OK wrappers.

## Validation
- [x] `uv run --extra test python -m pytest tests/test_vk_friends_adapter.py tests/test_ok_friends_adapter.py tests/test_friends_export_service.py tests/test_redaction_gateway.py` — 31 passed
- [x] `uv run --with ruff ruff check app/modules/friends_export/provider_adapter.py app/modules/vk_friends/adapters.py app/modules/ok_friends/adapters.py tests/test_vk_friends_adapter.py tests/test_ok_friends_adapter.py` — passed
- [x] `python .agents\skills\parsevk-service-architecture\scripts\validate-service.py --no-db services\api-gateway` — 28 passed
- [ ] `uv run --extra test python -m pytest` — 91 passed, 1 existing failure in `test_telegram_tgmbase_capabilities_describe_gateway_boundary` outside this scope

## Notes
- Public adapter import paths/classes are preserved.
- SSE event output remains backward-compatible.
- No vk-service endpoints, frontend consumers, polling interval, or provider contracts changed.