### PR TITLE
refactor(content): build monitoring queries with sqlalchemy

### DIFF
--- a/services/content-service/app/modules/monitoring/repository.py
+++ b/services/content-service/app/modules/monitoring/repository.py
@@ -2,10 +2,23 @@ import json
 import logging
 from datetime import datetime
 from typing import Any
-from sqlalchemy import delete, select, text
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 from app.db.models import MonitoringGroup
+from sqlalchemy import (
+    String,
+    cast,
+    column,
+    func,
+    literal,
+    null,
+    or_,
+    select,
+    table,
+    union_all,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlalchemy.sql.elements import quoted_name
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +57,7 @@ class MonitoringRepository:
         search: str | None = None,
         category: str | None = None,
     ) -> int:
-        # Для простоты посчитаем размер возвращенного списка
+        # Для простоты считаем размер возвращенного списка.
         groups = await self.get_groups(messenger=messenger, search=search, category=category)
         return len(groups)
 
@@ -53,15 +66,25 @@ class MonitoringRepository:
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
-    async def get_group_by_messenger_chat(self, messenger: str, chat_id: str) -> MonitoringGroup | None:
+    async def get_group_by_messenger_chat(
+        self,
+        messenger: str,
+        chat_id: str,
+    ) -> MonitoringGroup | None:
         query = select(MonitoringGroup).where(
             MonitoringGroup.messenger == messenger,
-            MonitoringGroup.chat_id == chat_id
+            MonitoringGroup.chat_id == chat_id,
         )
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
-    async def upsert_group(self, messenger: str, chat_id: str, name: str, category: str | None = None) -> MonitoringGroup:
+    async def upsert_group(
+        self,
+        messenger: str,
+        chat_id: str,
+        name: str,
+        category: str | None = None,
+    ) -> MonitoringGroup:
         group = await self.get_group_by_messenger_chat(messenger, chat_id)
         if group:
             group.name = name
@@ -72,7 +95,7 @@ class MonitoringRepository:
                 messenger=messenger,
                 chat_id=chat_id,
                 name=name,
-                category=category
+                category=category,
             )
             self.session.add(group)
         await self.session.flush()
@@ -100,95 +123,101 @@ class MonitoringRepository:
         if not keywords:
             return []
 
-        # Разрешаем целевые таблицы
         table_names = self._resolve_source_tables(sources)
         if not table_names:
             return []
 
-        # Строим параметры запроса
-        params = {}
-        conditions = []
-        
-        # Фильтрация по ключевым словам
-        for idx, keyword in enumerate(keywords):
-            param_key = f"keyword_{idx}"
-            params[param_key] = f"%{keyword}%"
-            conditions.append(f'"{self._cfg.monitor_message_text_column}" ILIKE :{param_key}')
-
-        where_clause = f'"{self._cfg.monitor_message_text_column}" IS NOT NULL AND ({ " OR ".join(conditions) })'
-
-        if from_date:
-            params["from_date"] = from_date
-            where_clause += f' AND "{self._cfg.monitor_message_created_at_column}" >= :from_date'
-
-        select_cols = [
-            f'"{self._cfg.monitor_message_id_column}" as id',
-            f'"{self._cfg.monitor_message_text_column}" as text',
-            f'"{self._cfg.monitor_message_created_at_column}" as "createdAt"',
-        ]
-        if self._cfg.monitor_message_author_column:
-            select_cols.append(f'"{self._cfg.monitor_message_author_column}" as author')
-        else:
-            select_cols.append("NULL as author")
-
-        if self._cfg.monitor_message_chat_column:
-            select_cols.append(f'"{self._cfg.monitor_message_chat_column}" as chat')
-        else:
-            select_cols.append("NULL as chat")
-
-        if self._cfg.monitor_message_metadata_column:
-            select_cols.append(f'"{self._cfg.monitor_message_metadata_column}" as metadata')
-        else:
-            select_cols.append("NULL as metadata")
-
-        # Формируем подзапросы для UNION
         subqueries = []
-        for idx, table in enumerate(table_names):
-            source_name = table.split(".")[-1]
+        for table_name in table_names:
+            msg_table = self._monitor_table(
+                table_name,
+                self._message_columns(include_group_columns=False),
+            )
+            text_col = self._monitor_column(msg_table, self._cfg.monitor_message_text_column)
+            created_at_col = self._monitor_column(
+                msg_table,
+                self._cfg.monitor_message_created_at_column,
+            )
+            filters = [
+                text_col.is_not(None),
+                or_(*(text_col.ilike(f"%{keyword}%") for keyword in keywords)),
+            ]
+            if from_date:
+                filters.append(created_at_col >= from_date)
+
             subqueries.append(
-                f"SELECT {', '.join(select_cols)}, '{source_name}' as source FROM \"{table}\" WHERE {where_clause}"
+                select(
+                    cast(
+                        self._monitor_column(msg_table, self._cfg.monitor_message_id_column),
+                        String,
+                    ).label("id"),
+                    text_col.label("text"),
+                    created_at_col.label("createdAt"),
+                    self._optional_monitor_column(
+                        msg_table,
+                        self._cfg.monitor_message_author_column,
+                        "author",
+                    ),
+                    self._optional_monitor_column(
+                        msg_table,
+                        self._cfg.monitor_message_chat_column,
+                        "chat",
+                    ),
+                    self._optional_monitor_column(
+                        msg_table,
+                        self._cfg.monitor_message_metadata_column,
+                        "metadata",
+                    ),
+                    literal(table_name.split(".")[-1]).label("source"),
+                ).where(*filters)
             )
 
-        params["limit"] = limit
-        params["offset"] = offset
-
         if len(subqueries) == 1:
-            sql = f"{subqueries[0]} ORDER BY \"{self._cfg.monitor_message_created_at_column}\" DESC LIMIT :limit OFFSET :offset"
+            combined = subqueries[0].subquery("combined")
         else:
-            sql = f"SELECT * FROM ({' UNION ALL '.join(subqueries)}) AS combined ORDER BY \"createdAt\" DESC LIMIT :limit OFFSET :offset"
+            combined = union_all(*subqueries).subquery("combined")
+        query = select(combined).order_by(combined.c.createdAt.desc()).limit(limit).offset(offset)
 
         rows = []
         async with self._mon_engine.connect() as conn:
-            result = await conn.execute(text(sql), params)
+            result = await conn.execute(query)
             for r in result:
-                # Извлекаем метаданные
-                meta = r.metadata
-                if meta and isinstance(meta, str):
-                    try:
-                        meta = json.loads(meta)
-                    except Exception:
-                        meta = {}
-                elif not meta:
-                    meta = {}
-
-                # Извлечение S3 URL и других полей из метаданных (как в NestJS)
+                meta = self._parse_metadata(r.metadata)
                 raw = meta.get("raw", {}) if isinstance(meta, dict) else {}
                 raw_s3 = raw.get("s3Info", {}) if isinstance(raw, dict) else {}
 
-                text_val = r.text or (raw.get("body") or raw.get("caption") or raw.get("text") if isinstance(raw, dict) else None) or meta.get("text") if isinstance(meta, dict) else None
-                url_val = raw_s3.get("url") or raw_s3.get("link") or raw.get("file_url") or raw.get("fileUrl") or raw.get("url") if isinstance(raw, dict) else None or meta.get("url") if isinstance(meta, dict) else None
-                type_val = raw.get("mimetype") or raw.get("type") if isinstance(raw, dict) else None or meta.get("type") if isinstance(meta, dict) else None
-                chat_name = meta.get("chat_name") or meta.get("chatName") or raw.get("chat_name") or raw.get("chatName") or raw.get("chat") or raw.get("title") if isinstance(raw, dict) else None
+                text_val = (
+                    r.text
+                    or self._metadata_value(raw, "body", "caption", "text")
+                    or self._metadata_value(meta, "text")
+                )
+                url_val = (
+                    self._metadata_value(raw_s3, "url", "link")
+                    or self._metadata_value(raw, "file_url", "fileUrl", "url")
+                    or self._metadata_value(meta, "url")
+                )
+                type_val = (
+                    self._metadata_value(raw, "mimetype", "type")
+                    or self._metadata_value(meta, "type")
+                )
+                chat_name = (
+                    self._metadata_value(meta, "chat_name", "chatName")
+                    or self._metadata_value(raw, "chat_name", "chatName", "chat", "title")
+                )
 
                 rows.append({
                     "id": str(r.id),
                     "text": text_val or r.text,
-                    "createdAt": r.createdAt.isoformat() if isinstance(r.createdAt, datetime) else r.createdAt,
+                    "createdAt": (
+                        r.createdAt.isoformat()
+                        if isinstance(r.createdAt, datetime)
+                        else r.createdAt
+                    ),
                     "author": r.author,
                     "chat": r.chat or chat_name,
                     "source": r.source,
                     "contentUrl": url_val,
-                    "contentType": type_val
+                    "contentType": type_val,
                 })
         return rows
 
@@ -197,58 +226,173 @@ class MonitoringRepository:
             logger.warning("External monitor database is not configured.")
             return []
 
-        # Если задана отдельная таблица групп
         if self._cfg.monitor_groups_table:
-            sql = f'SELECT DISTINCT "{self._cfg.monitor_group_chat_id_column}"::text as "chatId", "{self._cfg.monitor_group_name_column}"::text as "name" FROM "{self._cfg.monitor_groups_table}" WHERE "{self._cfg.monitor_group_chat_id_column}" IS NOT NULL AND "{self._cfg.monitor_group_name_column}" IS NOT NULL'
+            groups_table = self._monitor_table(
+                self._cfg.monitor_groups_table,
+                [
+                    self._cfg.monitor_group_chat_id_column,
+                    self._cfg.monitor_group_name_column,
+                ],
+            )
+            chat_id_col = self._monitor_column(groups_table, self._cfg.monitor_group_chat_id_column)
+            name_col = self._monitor_column(groups_table, self._cfg.monitor_group_name_column)
+            query = (
+                select(
+                    cast(chat_id_col, String).label("chatId"),
+                    cast(name_col, String).label("name"),
+                )
+                .distinct()
+                .where(chat_id_col.is_not(None), name_col.is_not(None))
+            )
             async with self._mon_engine.connect() as conn:
-                result = await conn.execute(text(sql))
+                result = await conn.execute(query)
                 return [{"chatId": r.chatId, "name": r.name} for r in result]
 
-        # Иначе вытаскиваем из метаданных сообщений
         table_names = self._resolve_source_tables(sources)
         if not table_names:
             return []
 
         subqueries = []
-        for table in table_names:
-            # Пытаемся вытащить chat_id и name из колонок или из JSONB метаданных
-            chat_id_expr = f'"{self._cfg.monitor_group_chat_id_column}"::text' if self._cfg.monitor_message_chat_column else 'NULL::text'
-            name_expr = f'"{self._cfg.monitor_message_chat_column}"::text' if self._cfg.monitor_message_chat_column else 'NULL::text'
-            
-            if self._cfg.monitor_message_metadata_column:
-                meta = f'"{self._cfg.monitor_message_metadata_column}"::jsonb'
-                chat_id_expr = f"COALESCE({chat_id_expr}, {meta}->>'chat_id', {meta}->>'chatId', {meta}->'raw'->>'chat_id', {meta}->'raw'->>'chatId')"
-                name_expr = f"COALESCE({name_expr}, {meta}->>'chat_name', {meta}->>'chatName', {meta}->>'title', {meta}->'raw'->>'chat_name', {meta}->'raw'->>'chatName', {meta}->'raw'->>'title')"
-
-            subqueries.append(
-                f'SELECT DISTINCT {chat_id_expr} as "chatId", {name_expr} as "name" FROM "{table}"'
+        for table_name in table_names:
+            msg_table = self._monitor_table(
+                table_name,
+                self._message_columns(include_group_columns=True),
+            )
+            chat_id_expr = (
+                cast(
+                    self._monitor_column(msg_table, self._cfg.monitor_group_chat_id_column),
+                    String,
+                )
+                if self._cfg.monitor_message_chat_column
+                else null()
+            )
+            name_expr = (
+                cast(self._monitor_column(msg_table, self._cfg.monitor_message_chat_column), String)
+                if self._cfg.monitor_message_chat_column
+                else null()
             )
 
-        sql = f'SELECT DISTINCT "chatId", "name" FROM ({ " UNION ALL ".join(subqueries) }) AS combined WHERE "chatId" IS NOT NULL AND "name" IS NOT NULL'
-        
+            if self._cfg.monitor_message_metadata_column:
+                metadata = cast(
+                    self._monitor_column(msg_table, self._cfg.monitor_message_metadata_column),
+                    JSONB,
+                )
+                chat_id_expr = func.coalesce(
+                    chat_id_expr,
+                    metadata["chat_id"].astext,
+                    metadata["chatId"].astext,
+                    metadata["raw"]["chat_id"].astext,
+                    metadata["raw"]["chatId"].astext,
+                )
+                name_expr = func.coalesce(
+                    name_expr,
+                    metadata["chat_name"].astext,
+                    metadata["chatName"].astext,
+                    metadata["title"].astext,
+                    metadata["raw"]["chat_name"].astext,
+                    metadata["raw"]["chatName"].astext,
+                    metadata["raw"]["title"].astext,
+                )
+
+            subqueries.append(
+                select(chat_id_expr.label("chatId"), name_expr.label("name")).distinct()
+            )
+
+        combined = union_all(*subqueries).subquery("combined")
+        query = (
+            select(combined.c.chatId.label("chatId"), combined.c.name)
+            .distinct()
+            .where(combined.c.chatId.is_not(None), combined.c.name.is_not(None))
+        )
+
         async with self._mon_engine.connect() as conn:
-            result = await conn.execute(text(sql))
+            result = await conn.execute(query)
             return [{"chatId": r.chatId, "name": r.name} for r in result]
 
     async def find_external_keywords(self) -> list[str] | None:
         if not self._mon_engine or not self._cfg.monitor_keywords_table:
             return None
 
-        sql = f'SELECT "{self._cfg.monitor_keyword_word_column}"::text as word FROM "{self._cfg.monitor_keywords_table}" WHERE "{self._cfg.monitor_keyword_word_column}" IS NOT NULL'
+        keywords_table = self._monitor_table(
+            self._cfg.monitor_keywords_table,
+            [self._cfg.monitor_keyword_word_column],
+        )
+        word_col = self._monitor_column(keywords_table, self._cfg.monitor_keyword_word_column)
+        query = select(cast(word_col, String).label("word")).where(word_col.is_not(None))
         async with self._mon_engine.connect() as conn:
-            result = await conn.execute(text(sql))
+            result = await conn.execute(query)
             return list(set(r.word.strip() for r in result if r.word.strip()))
 
     def _resolve_source_tables(self, sources: list[str] | None) -> list[str]:
-        default_tables = [t.strip() for t in self._cfg.monitor_messages_table.split(",") if t.strip()]
+        default_tables = [
+            table_name.strip()
+            for table_name in self._cfg.monitor_messages_table.split(",")
+            if table_name.strip()
+        ]
         if not sources:
             return default_tables
 
         resolved = []
         sources_lower = [s.lower() for s in sources]
-        for table in default_tables:
-            table_lower = table.lower()
-            source_name = table.split(".")[-1].lower()
+        for table_name in default_tables:
+            table_lower = table_name.lower()
+            source_name = table_name.split(".")[-1].lower()
             if table_lower in sources_lower or source_name in sources_lower:
-                resolved.append(table)
+                resolved.append(table_name)
         return resolved or default_tables
+
+    def _message_columns(self, *, include_group_columns: bool) -> list[str]:
+        names = [
+            self._cfg.monitor_message_id_column,
+            self._cfg.monitor_message_text_column,
+            self._cfg.monitor_message_created_at_column,
+            self._cfg.monitor_message_author_column,
+            self._cfg.monitor_message_chat_column,
+            self._cfg.monitor_message_metadata_column,
+        ]
+        if include_group_columns:
+            names.append(self._cfg.monitor_group_chat_id_column)
+        return [name for name in names if name]
+
+    def _monitor_table(self, table_name: str, columns: list[str]):
+        unique_columns = []
+        for name in columns:
+            if name not in unique_columns:
+                unique_columns.append(name)
+        return table(
+            quoted_name(table_name, True),
+            *(self._quoted_column(name) for name in unique_columns),
+        )
+
+    def _monitor_column(self, selectable, column_name: str):
+        return selectable.c[column_name]
+
+    def _optional_monitor_column(self, selectable, column_name: str | None, label: str):
+        if not column_name:
+            return null().label(label)
+        return self._monitor_column(selectable, column_name).label(label)
+
+    def _quoted_column(self, column_name: str):
+        if column_name == self._cfg.monitor_message_metadata_column:
+            return column(quoted_name(column_name, True), JSONB)
+        return column(quoted_name(column_name, True))
+
+    def _parse_metadata(self, value: Any) -> dict:
+        if value and isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+            except Exception:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        if value and isinstance(value, dict):
+            return value
+        return {}
+
+    def _metadata_value(self, source: Any, *keys: str) -> Any:
+        if not isinstance(source, dict):
+            return None
+        for key in keys:
+            value = source.get(key)
+            if value:
+                return value
+        return None

--- a/services/content-service/tests/test_monitoring_repository.py
+++ b/services/content-service/tests/test_monitoring_repository.py
@@ -1,0 +1,150 @@
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.sql.elements import TextClause
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _service_path import use_service_path  # noqa: E402
+
+use_service_path()
+
+from app.modules.monitoring.repository import MonitoringRepository  # noqa: E402
+
+
+class FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class FakeConnection:
+    def __init__(self, rows, statements):
+        self._rows = rows
+        self._statements = statements
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return None
+
+    async def execute(self, statement):
+        self._statements.append(statement)
+        return FakeResult(self._rows)
+
+
+class FakeEngine:
+    def __init__(self, rows):
+        self._rows = rows
+        self.statements = []
+
+    def connect(self):
+        return FakeConnection(self._rows, self.statements)
+
+
+@pytest.fixture
+def monitor_cfg():
+    return SimpleNamespace(
+        monitor_messages_table="monitor_messages",
+        monitor_message_id_column="id",
+        monitor_message_text_column="text",
+        monitor_message_created_at_column="created_at",
+        monitor_message_author_column="author",
+        monitor_message_chat_column="chat",
+        monitor_message_metadata_column="metadata",
+        monitor_groups_table="monitor_groups",
+        monitor_group_chat_id_column="chat_id",
+        monitor_group_name_column="name",
+        monitor_keywords_table="monitor_keywords",
+        monitor_keyword_word_column="word",
+    )
+
+
+def make_repository(cfg, rows):
+    engine = FakeEngine(rows)
+    repository = MonitoringRepository(AsyncMock(), cfg=cfg, mon_engine=engine)
+    return repository, engine
+
+
+@pytest.mark.asyncio
+async def test_find_external_messages_uses_sqlalchemy_statement(monitor_cfg):
+    created_at = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+    metadata = {
+        "raw": {
+            "body": "fallback text",
+            "s3Info": {"url": "https://cdn.example/file.jpg"},
+        },
+        "chatName": "fallback chat",
+    }
+    repository, engine = make_repository(
+        monitor_cfg,
+        [
+            SimpleNamespace(
+                id=10,
+                text=None,
+                createdAt=created_at,
+                author="author1",
+                chat=None,
+                source="monitor_messages",
+                metadata=json.dumps(metadata),
+            )
+        ],
+    )
+
+    rows = await repository.find_external_messages(["fallback"], limit=20, offset=0)
+
+    assert rows == [
+        {
+            "id": "10",
+            "text": "fallback text",
+            "createdAt": created_at.isoformat(),
+            "author": "author1",
+            "chat": "fallback chat",
+            "source": "monitor_messages",
+            "contentUrl": "https://cdn.example/file.jpg",
+            "contentType": None,
+        }
+    ]
+    assert len(engine.statements) == 1
+    assert not isinstance(engine.statements[0], TextClause)
+
+
+@pytest.mark.asyncio
+async def test_find_external_groups_uses_sqlalchemy_statement(monitor_cfg):
+    repository, engine = make_repository(
+        monitor_cfg,
+        [SimpleNamespace(chatId="123", name="Group 1")],
+    )
+
+    rows = await repository.find_external_groups()
+
+    assert rows == [{"chatId": "123", "name": "Group 1"}]
+    assert len(engine.statements) == 1
+    assert not isinstance(engine.statements[0], TextClause)
+
+
+@pytest.mark.asyncio
+async def test_find_external_keywords_uses_sqlalchemy_statement(monitor_cfg):
+    repository, engine = make_repository(
+        monitor_cfg,
+        [
+            SimpleNamespace(word=" alpha "),
+            SimpleNamespace(word="beta"),
+            SimpleNamespace(word=""),
+            SimpleNamespace(word="alpha"),
+        ],
+    )
+
+    words = await repository.find_external_keywords()
+
+    assert words is not None
+    assert sorted(words) == ["alpha", "beta"]
+    assert len(engine.statements) == 1
+    assert not isinstance(engine.statements[0], TextClause)


### PR DESCRIPTION
Closes #251

## Summary
- Replaced raw external monitoring SQL strings with SQLAlchemy Core statements in `MonitoringRepository`.
- Preserved message metadata fallback mapping for text, chat, URL and content type.
- Added repository-level tests that assert external message/group/keyword queries are not `TextClause` calls.

## Validation
- [x] `uv run --with ruff ruff check app/modules/monitoring/repository.py tests/test_monitoring_repository.py`
- [x] `uv run --extra test python -m pytest tests/test_monitoring.py tests/test_monitoring_repository.py`
- [x] `uv run --extra test python -m pytest`
- [x] `python -m compileall services/content-service/app/modules/monitoring`
- [x] `python .agents/skills/parsevk-service-architecture/scripts/validate-service.py services/content-service`

## Notes
- Full pytest still emits existing tgmbase Pydantic V2 deprecation warnings and AsyncMock resource warnings outside this scope.